### PR TITLE
readme fixes

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,7 @@
 # Build Service Node
 FROM debian:buster-slim as mentat-node-builder
 ARG SERVICE="rosetta-snarkos"
-ARG BRANCH="containerized-deployment"
+ARG BRANCH="main"
 
 RUN mkdir -p /app \
     && chown -R nobody:nogroup /app
@@ -15,7 +15,7 @@ RUN curl --proto '=https' --tlsv1.2 -sSf https://raw.githubusercontent.com/monad
 # Build Rosetta Mentat
 FROM debian:buster-slim as rosetta-mentat-builder
 ARG SERVICE="rosetta-snarkos"
-ARG BRANCH="containerized-deployment"
+ARG BRANCH="main"
 
 RUN mkdir -p /app \
     && chown -R nobody:nogroup /app
@@ -29,7 +29,7 @@ ENV PATH=/root/.cargo/bin:$PATH
 
 RUN git clone -b $BRANCH https://github.com/monadicus/mentat.git \
     && cd mentat \
-    && cargo build --release --bin "$SERVICE" --features "$SERVICE" \
+    && cargo build --release --bin "$SERVICE" \
     && mv ./target/release/"$SERVICE" /app
 
 ## Build Final Image

--- a/Makefile
+++ b/Makefile
@@ -1,17 +1,17 @@
-.PHONY: deps build run lint mocks run-mainnet-online run-mainnet-offline run-testnet-online \
-	run-testnet-offline check-comments add-license check-license shorten-lines test \
-	coverage spellcheck salus build-local coverage-local format check-format
+.PHONY: build buld-local build-release run-mainnet-online run-mainnet-offline run-testnet-online \
+	run-testnet-offline tracing format check-format test clean
 
 PWD=$(shell pwd)
 NOFILE=100000
 
 SERVICE=rosetta-snarkos
+BRANCH=main
 
 build:
 	docker build -t mentat-$(SERVICE):latest https://github.com/monadicus/mentat.git --build-arg SERVICE=$(SERVICE)
 
 build-local:
-	docker build --no-cache -t mentat-$(SERVICE):latest . --build-arg SERVICE=$(SERVICE)
+	docker build -t mentat-$(SERVICE):latest . --build-arg SERVICE=$(SERVICE) --build-arg BRANCH=$(BRANCH)
 
 build-release:
 	# make sure to always set version with vX.X.X

--- a/Makefile
+++ b/Makefile
@@ -11,7 +11,7 @@ build:
 	docker build -t mentat-$(SERVICE):latest https://github.com/monadicus/mentat.git --build-arg SERVICE=$(SERVICE)
 
 build-local:
-	docker build -t mentat-$(SERVICE):latest . --build-arg SERVICE=$(SERVICE) --build-arg BRANCH=$(BRANCH)
+	docker build --no-cache -t mentat-$(SERVICE):latest . --build-arg SERVICE=$(SERVICE) --build-arg BRANCH=$(BRANCH)
 
 build-release:
 	# make sure to always set version with vX.X.X

--- a/README.md
+++ b/README.md
@@ -48,11 +48,13 @@ Change `rosetta-snarkos` with any other Mentat supported Blockchain.
 
 ### From GitHub
 
-To download the pre-built Docker image from the latest release, run:
+To build the Docker image from the latest release, run:
 
 ```text
-curl -sSfL https://raw.githubusercontent.com/monadicus/mentat/main/rosetta-snarkos/install.sh | sh -s
+docker build -t mentat-rosetta-snarkos:latest https://github.com/monadicus/mentat.git --build-arg SERVICE=rosetta-snarkos
 ```
+
+Replace `rosetta-snarkos` with whatever service we offer.
 
 ### From Source
 
@@ -135,7 +137,9 @@ Interested in helping fix issues in this repository? You can find to-dos in the 
 
 # Development
 
-TODO after swapping to `bazel` from `make`.
+- `cargo +nightly fmt --check --all` To check the formatting of the source code and all rosetta implementations.
+- `cargo clippy --all` To lint  the formatting of the source code and all rosetta implementations.
+- `make build-local SERVICE=rosetta-snarkos BRANCH=main` To build the local docker image. The arguments are optional and default to shown values.
 
 # License
 

--- a/rosetta-snarkos/install.sh
+++ b/rosetta-snarkos/install.sh
@@ -1,4 +1,4 @@
-#!/usr/bin/env bash
+#!/usr/bin/env sh
 
 apt-get install -y build-essential curl clang gcc git libssl-dev llvm make pkg-config xz-utils
 


### PR DESCRIPTION
Adds in the development section.

Found out you can use `make` on windows without `mingw` if you install it through `scoop`.

Closes #32.