### PR TITLE
added blockchain and network check

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1261,6 +1261,7 @@ dependencies = [
  "axum",
  "color-backtrace",
  "ed25519-dalek",
+ "hyper",
  "indexmap",
  "mina-hasher",
  "mina-signer",

--- a/mentat/Cargo.toml
+++ b/mentat/Cargo.toml
@@ -49,3 +49,4 @@ tracing-error = { version = "0.2.0", optional = true }
 tracing-opentelemetry = { version = "0.17.2", optional = true }
 tracing-subscriber = { version = "0.3.9", optional = true, features = ["env-filter"] }
 tracing-tree = { version = "0.2.0", optional = true }
+hyper = { version = "0.14" }

--- a/mentat/src/identifiers/network_identifier.rs
+++ b/mentat/src/identifiers/network_identifier.rs
@@ -2,12 +2,11 @@ use std::str::FromStr;
 
 use axum::http::Extensions;
 
+use super::*;
 use crate::{
     errors::MentatError,
     server::{Network, Server},
 };
-
-use super::*;
 
 /// The network_identifier specifies which network a particular object is
 /// associated with.

--- a/mentat/src/server/middleware_checks.rs
+++ b/mentat/src/server/middleware_checks.rs
@@ -1,0 +1,20 @@
+use axum::{middleware::Next, response::IntoResponse};
+use hyper::{Body, Request};
+use serde_json::Value;
+
+use crate::{errors::MentatError, identifiers::NetworkIdentifier};
+
+pub async fn middleware_check(
+    req: Request<Body>,
+    next: Next<Body>,
+) -> Result<impl IntoResponse, MentatError> {
+    let (parts, body) = req.into_parts();
+    let extensions = &parts.extensions;
+    let bytes = hyper::body::to_bytes(body).await?;
+    let json = serde_json::from_slice::<Value>(&bytes).unwrap();
+
+    NetworkIdentifier::check(extensions, &json).await?;
+
+    let req = Request::from_parts(parts, Body::from(bytes));
+    Ok(next.run(req).await)
+}

--- a/mentat/src/server/mod.rs
+++ b/mentat/src/server/mod.rs
@@ -6,16 +6,9 @@ mod logging;
 mod middleware_checks;
 mod node;
 
-use self::{
-    dummy_call::DummyCallApi, dummy_construction::DummyConstructionApi, dummy_data::DummyDataApi,
-    dummy_indexer::DummyIndexerApi, middleware_checks::middleware_check,
-};
-pub use node::*;
-
-use crate::{api::*, requests::*, responses::*};
-
 use std::{
-    env, fmt,
+    env,
+    fmt,
     net::{Ipv4Addr, SocketAddr},
     str::FromStr,
     sync::Arc,
@@ -25,8 +18,18 @@ use axum::{
     extract::{self, ConnectInfo, Extension},
     middleware,
 };
+pub use node::*;
 use reqwest::Client;
 use tracing::info;
+
+use self::{
+    dummy_call::DummyCallApi,
+    dummy_construction::DummyConstructionApi,
+    dummy_data::DummyDataApi,
+    dummy_indexer::DummyIndexerApi,
+    middleware_checks::middleware_check,
+};
+use crate::{api::*, requests::*, responses::*};
 
 #[derive(Clone, Copy, PartialEq, Eq)]
 pub enum Network {

--- a/rosetta-bitcoin/src/main.rs
+++ b/rosetta-bitcoin/src/main.rs
@@ -12,7 +12,7 @@ mod indexer_api;
 
 #[tokio::main]
 async fn main() -> Result<(), Box<dyn std::error::Error>> {
-    let mut server = Server::new();
+    let mut server = Server::new(String::from("BITCOIN"));
     server.with_dyn_call_api(Arc::new(call_api::BitcoinCallApi::default()));
     server.with_dyn_construction_api(Arc::new(construction_api::BitcoinConstructionApi::default()));
     server.with_dyn_data_api(Arc::new(data_api::BitcoinDataApi::default()));

--- a/rosetta-snarkos/src/main.rs
+++ b/rosetta-snarkos/src/main.rs
@@ -15,7 +15,7 @@ use request::SnarkosJrpc;
 
 #[tokio::main]
 async fn main() -> Result<(), Box<dyn std::error::Error>> {
-    let mut server = Server::new();
+    let mut server = Server::new(String::from("SNARKOS"));
     server.with_dyn_call_api(Arc::new(call_api::SnarkosCallApi::default()));
     server.with_dyn_construction_api(Arc::new(construction_api::SnarkosConstructionApi::default()));
     server.with_dyn_data_api(Arc::new(data_api::SnarkosDataApi::default()));


### PR DESCRIPTION
added a middleware layer that can be used to check general properties of requests.

added a check in the middleware layer that ensures the specified network and blockchain match the current node before passing on the request. the only difference on the users end is now they need to provide a blockchain name when creating a new server instance.

closes #44 