### PR TITLE
simplified `NodeConf::spawn_node` method

### DIFF
--- a/mentat/src/conf/configuration.rs
+++ b/mentat/src/conf/configuration.rs
@@ -18,7 +18,7 @@ pub trait NodeConf: Clone + Default + Send + Serialize + Sync + 'static {
 
     fn node_command(config: &Configuration<Self>) -> Command;
 
-    async fn start_node(config: &Configuration<Self>) -> Result<(), Box<dyn std::error::Error>> {
+    fn start_node(config: &Configuration<Self>) -> Result<(), Box<dyn std::error::Error>> {
         let mut child = Self::node_command(config)
             .stderr(Stdio::piped())
             .stdout(Stdio::piped())

--- a/mentat/src/conf/configuration.rs
+++ b/mentat/src/conf/configuration.rs
@@ -3,7 +3,7 @@ use std::{
     io::{BufRead, BufReader, Read},
     net::Ipv4Addr,
     path::{Path, PathBuf},
-    process::Child,
+    process::{Command, Stdio},
     thread,
 };
 
@@ -14,11 +14,15 @@ use super::*;
 
 #[async_trait]
 pub trait NodeConf: Clone + Default + Send + Serialize + Sync + 'static {
-    async fn start_node(config: &Configuration<Self>) -> Result<Child, Box<dyn std::error::Error>>;
-
     fn node_name() -> String;
 
-    async fn log_node(mut child: Child) {
+    fn node_command(config: &Configuration<Self>) -> Command;
+
+    async fn start_node(config: &Configuration<Self>) -> Result<(), Box<dyn std::error::Error>> {
+        let mut child = Self::node_command(config)
+            .stderr(Stdio::piped())
+            .stdout(Stdio::piped())
+            .spawn()?;
         let stdout = child.stdout.take().unwrap();
         let stderr = child.stderr.take().unwrap();
 
@@ -39,6 +43,7 @@ pub trait NodeConf: Clone + Default + Send + Serialize + Sync + 'static {
         let name = Self::node_name();
         spawn_reader(name.clone(), stdout, false);
         spawn_reader(name, stderr, true);
+        Ok(())
     }
 
     fn build_url(conf: &Configuration<Self>) -> String {

--- a/mentat/src/server/mod.rs
+++ b/mentat/src/server/mod.rs
@@ -142,7 +142,7 @@ impl<Types: ServerType> Server<Types> {
         logging::setup()?;
 
         if !self.configuration.mode.is_offline() {
-            Types::CustomConfig::start_node(&self.configuration).await?;
+            Types::CustomConfig::start_node(&self.configuration)?;
         }
 
         let rpc_caller = RpcCaller::new(&self.configuration);

--- a/mentat/src/server/mod.rs
+++ b/mentat/src/server/mod.rs
@@ -142,8 +142,7 @@ impl<Types: ServerType> Server<Types> {
         logging::setup()?;
 
         if !self.configuration.mode.is_offline() {
-            let child = Types::CustomConfig::start_node(&self.configuration).await?;
-            Types::CustomConfig::log_node(child).await;
+            Types::CustomConfig::start_node(&self.configuration).await?;
         }
 
         let rpc_caller = RpcCaller::new(&self.configuration);

--- a/rosetta-bitcoin/src/node.rs
+++ b/rosetta-bitcoin/src/node.rs
@@ -1,7 +1,4 @@
-use std::{
-    path::PathBuf,
-    process::{Child, Command, Stdio},
-};
+use std::{path::PathBuf, process::Command};
 
 use mentat::{
     async_trait,
@@ -34,21 +31,19 @@ impl NodeConf for NodeConfig {
         )
     }
 
-    async fn start_node(config: &Configuration<Self>) -> Result<Child, Box<dyn std::error::Error>> {
-        Ok(Command::new(&config.node_path)
-            .args(&[
-                // TODO cant bind to address without setting a whitelist
-                // &format!("--bind={address}:4132"),
-                // &format!("--rpcbind={address}:3032"),
-                "-port=4132",
-                &format!("-rpcport={}", config.node_rpc_port),
-                &format!("-rpcuser={}", config.custom.user),
-                &format!("-rpcpassword={}", config.custom.pass),
-                "-txindex=1",
-                &format!("--datadir={}", config.custom.data_dir.display()),
-            ])
-            .stderr(Stdio::piped())
-            .stdout(Stdio::piped())
-            .spawn()?)
+    fn node_command(config: &Configuration<Self>) -> Command {
+        let mut command = Command::new(&config.node_path);
+        command.args(&[
+            // TODO cant bind to address without setting a whitelist
+            // &format!("--bind={address}:4132"),
+            // &format!("--rpcbind={address}:3032"),
+            "-port=4132",
+            &format!("-rpcport={}", config.node_rpc_port),
+            &format!("-rpcuser={}", config.custom.user),
+            &format!("-rpcpassword={}", config.custom.pass),
+            "-txindex=1",
+            &format!("--datadir={}", config.custom.data_dir.display()),
+        ]);
+        command
     }
 }

--- a/rosetta-snarkos/src/node.rs
+++ b/rosetta-snarkos/src/node.rs
@@ -1,4 +1,4 @@
-use std::process::{Child, Command, Stdio};
+use std::process::Command;
 
 use mentat::{
     async_trait,
@@ -16,20 +16,18 @@ impl NodeConf for NodeConfig {
         String::from("SnarkOS")
     }
 
-    async fn start_node(config: &Configuration<Self>) -> Result<Child, Box<dyn std::error::Error>> {
+    fn node_command(config: &Configuration<Self>) -> Command {
         // TODO: make it so snarkos checks for updates and rebuilds automatically.
-        Ok(Command::new(&config.node_path)
-            .args(&[
-                "--node",
-                &format!("{}:4132", config.address),
-                "--rpc",
-                &format!("{}:{}", config.address, config.node_rpc_port),
-                "--trial",
-                "--verbosity",
-                "2",
-            ])
-            .stderr(Stdio::piped())
-            .stdout(Stdio::piped())
-            .spawn()?)
+        let mut command = Command::new(&config.node_path);
+        command.args(&[
+            "--node",
+            &format!("{}:4132", config.address),
+            "--rpc",
+            &format!("{}:{}", config.address, config.node_rpc_port),
+            "--trial",
+            "--verbosity",
+            "2",
+        ]);
+        command
     }
 }


### PR DESCRIPTION
i realized `NodeConf::spawn_node` required the user to pipe stdout/stderr yet gave no warning to this. to solve this i made it so the user just has to specify the command they want to execute and then the default implementation of `start_node` will do the rest.


### OLD
```rust
    async fn start_node(config: &Configuration<Self>) -> Result<Child, Box<dyn std::error::Error>> {
        // TODO: make it so snarkos checks for updates and rebuilds automatically.
        Ok(Command::new(&config.node_path)
            .args(&[
                "--node",
                &format!("{}:4132", config.address),
                "--rpc",
                &format!("{}:{}", config.address, config.node_rpc_port),
                "--trial",
                "--verbosity",
                "2",
            ])
            .stderr(Stdio::piped())
            .stdout(Stdio::piped())
            .spawn()?)
    }
```

### NEW
```rust
    fn node_command(config: &Configuration<Self>) -> Command {
        // TODO: make it so snarkos checks for updates and rebuilds automatically.
        let mut command = Command::new(&config.node_path);
        command.args(&[
            "--node",
            &format!("{}:4132", config.address),
            "--rpc",
            &format!("{}:{}", config.address, config.node_rpc_port),
            "--trial",
            "--verbosity",
            "2",
        ]);
        command
    }
```