### PR TITLE
made `main` proc macro less redundant

### DIFF
--- a/mentat-macros/src/lib.rs
+++ b/mentat-macros/src/lib.rs
@@ -6,10 +6,19 @@ use proc_macro::TokenStream;
 use proc_macro2::{Span, TokenStream as TokenStream2};
 use quote::quote;
 use syn::{
-    self, parse_macro_input, AttributeArgs, GenericArgument, Ident, ItemFn, ItemStruct, Meta,
+    self,
+    parse_macro_input,
+    AttributeArgs,
+    GenericArgument,
+    Ident,
+    ItemFn,
+    ItemStruct,
+    Meta,
     NestedMeta,
     PathArguments::{self},
-    PathSegment, ReturnType, Type,
+    PathSegment,
+    ReturnType,
+    Type,
 };
 
 /// parses the provided macro argument for the optional cache type

--- a/mentat-macros/src/lib.rs
+++ b/mentat-macros/src/lib.rs
@@ -75,10 +75,10 @@ fn get_function_return_server_type(f: &ItemFn) -> Result<&Ident, TokenStream> {
     .into())
 }
 
-/// generates code to derive Clone and Default on a user supplied `ServerType`
+/// generates code to derive Clone on a user supplied `ServerType`
 fn gen_derive(server_def: &ItemStruct) -> TokenStream2 {
     quote!(
-        #[::std::prelude::v1::derive(::std::clone::Clone, ::std::default::Default)]
+        #[::std::prelude::v1::derive(::std::clone::Clone)]
         #server_def
     )
 }

--- a/mentat-macros/src/lib.rs
+++ b/mentat-macros/src/lib.rs
@@ -3,12 +3,26 @@ extern crate proc_macro;
 mod route_builder;
 
 use proc_macro::TokenStream;
-use proc_macro2::{Span, TokenStream as TokenStream2};
+use proc_macro2::TokenStream as TokenStream2;
 use quote::quote;
-use syn::{self, parse_macro_input, AttributeArgs, Ident, ItemFn, ItemStruct, Meta, NestedMeta};
+use syn::{
+    self,
+    parse_macro_input,
+    AttributeArgs,
+    GenericArgument,
+    Ident,
+    ItemFn,
+    ItemStruct,
+    Meta,
+    NestedMeta,
+    PathArguments::{self},
+    PathSegment,
+    ReturnType,
+    Type,
+};
 
-/// parses the provided meta argument for the optional cache type
-fn parse_cache_inner_type(arg: &NestedMeta) -> &Ident {
+/// parses the provided macro argument for the optional cache type
+fn get_cache_inner_type(arg: &NestedMeta) -> &Ident {
     match arg {
         NestedMeta::Meta(Meta::Path(path)) => match path.get_ident() {
             Some(id) => id,
@@ -18,34 +32,71 @@ fn parse_cache_inner_type(arg: &NestedMeta) -> &Ident {
     }
 }
 
-fn gen_derive_clone(server_def: &ItemStruct) -> TokenStream2 {
+/// mutates the provided main function's name to `__mentat_main_server_call` so
+/// that it can be called from mentat's `main` function
+fn swap_main_name(f: &mut ItemFn) -> Result<(), TokenStream> {
+    if f.sig.ident == "main" {
+        f.sig.ident = Ident::new("__mentat_main_server_call", f.sig.ident.span());
+        Ok(())
+    } else {
+        Err(syn::Error::new(
+            f.sig.ident.span(),
+            format!("expected function name `main` found `{}`", f.sig.ident),
+        )
+        .into_compile_error()
+        .into())
+    }
+}
+
+/// matches the provided main function for the `Server`'s `ServerType`
+fn get_function_return_server_type(f: &ItemFn) -> Result<&Ident, TokenStream> {
+    // TODO this is horribly nested but they dont provide any helper functions to
+    // avoid this
+    if let ReturnType::Type(_, t) = &f.sig.output {
+        if let Type::Path(t) = &**t {
+            if let Some(PathSegment {
+                arguments: PathArguments::AngleBracketed(t),
+                ..
+            }) = t.path.segments.first()
+            {
+                if let Some(GenericArgument::Type(Type::Path(t))) = t.args.first() {
+                    if let Some(t) = t.path.get_ident() {
+                        return Ok(t);
+                    }
+                }
+            }
+        }
+    }
+    Err(syn::Error::new(
+        f.sig.ident.span(),
+        "expected function to return `Server<ServerType>` instance",
+    )
+    .into_compile_error()
+    .into())
+}
+
+/// generates code to derive Clone and Default on a user supplied `ServerType`
+fn gen_derive(server_def: &ItemStruct) -> TokenStream2 {
     quote!(
-        #[::std::prelude::v1::derive(::std::clone::Clone)]
+        #[::std::prelude::v1::derive(::std::clone::Clone, ::std::default::Default)]
         #server_def
     )
 }
 
+/// generates the main function for the given mentat implementation
 fn gen_main(
-    preamble: Option<&ItemFn>,
+    server_call: &TokenStream2,
     server_type: &Ident,
-    cacher: Option<&Ident>,
+    cache_type: Option<&Ident>,
 ) -> TokenStream2 {
-    let pre_main_call = preamble.map(|f| {
-        let sig = &f.sig.ident;
-        quote!(
-            #sig().await;
-        )
-    });
-
-    let routes = route_builder::build_routes(server_type, cacher);
+    let routes = route_builder::build_routes(server_type, cache_type);
 
     quote!(
         use ::mentat::macro_exports::tokio;
-        #[::mentat::macro_exports::tokio::main]
+        #[tokio::main]
         async fn main() -> ::std::result::Result<(), ::std::boxed::Box<dyn ::std::error::Error>> {
-            #pre_main_call
             use ::mentat::macro_exports::*;
-            let server = <#server_type>::build_server();
+            let server = #server_call;
             let mut app = Router::new();
             #routes
             server.serve(app).await
@@ -53,42 +104,42 @@ fn gen_main(
     )
 }
 
+/// a macro for generating mentat routes from a default `Server` instance
 #[proc_macro_attribute]
 pub fn mentat(attr: TokenStream, item: TokenStream) -> TokenStream {
     let args = parse_macro_input!(attr as AttributeArgs);
-    let cache_type = args.get(0).map(parse_cache_inner_type);
+    let cache_type = args.get(0).map(get_cache_inner_type);
 
     let server_def = parse_macro_input!(item as ItemStruct);
+    let server_type = &server_def.ident;
+    let server_call = quote!(Server::<#server_type>::default());
 
     let mut out = TokenStream2::new();
-    out.extend(gen_derive_clone(&server_def));
-    out.extend(gen_main(None, &server_def.ident, cache_type));
+    out.extend(gen_derive(&server_def));
+    out.extend(gen_main(&server_call, server_type, cache_type));
     out.into()
 }
 
+/// a macro for generating mentat routes from a user supplied `Server` instance
 #[proc_macro_attribute]
 pub fn main(attr: TokenStream, item: TokenStream) -> TokenStream {
+    let args = parse_macro_input!(attr as AttributeArgs);
+    let cache_type = args.get(0).map(get_cache_inner_type);
+
     let mut function = parse_macro_input!(item as ItemFn);
-    if function.sig.ident != "main" {
-        panic!(
-            "expected function name `main` found `{}`",
-            function.sig.ident
-        );
-    } else {
-        function.sig.ident = Ident::new("__mentat_main_preamble_fn", Span::call_site());
+    if let Err(e) = swap_main_name(&mut function) {
+        return e;
     }
 
-    let args = parse_macro_input!(attr as AttributeArgs);
-    let server_type = match args.get(0) {
-        Some(NestedMeta::Meta(Meta::Path(path))) => {
-            path.get_ident().expect("expected type `ServerType`")
-        }
-        _ => panic!("expected type `ServerType`"),
+    let server_type = match get_function_return_server_type(&function) {
+        Ok(t) => t,
+        Err(e) => return e,
     };
-    let cache_type = args.get(1).map(parse_cache_inner_type);
+    let function_name = &function.sig.ident;
+    let server_call = quote!(#function_name().await);
 
     let mut out = TokenStream2::new();
     out.extend(quote!(#function));
-    out.extend(gen_main(Some(&function), server_type, cache_type));
+    out.extend(gen_main(&server_call, server_type, cache_type));
     out.into()
 }

--- a/mentat-macros/src/route_builder.rs
+++ b/mentat-macros/src/route_builder.rs
@@ -170,7 +170,7 @@ struct ApiGroup {
     route_groups: &'static [RouteGroup],
 }
 
-pub fn build_routes(server_type: &Ident, cacher: Option<&Ident>) -> TokenStream2 {
+pub fn build_routes(server_type: &Ident, cache_type: Option<&Ident>) -> TokenStream2 {
     let mut out = TokenStream2::new();
 
     for api_group in ROUTES {
@@ -179,7 +179,7 @@ pub fn build_routes(server_type: &Ident, cacher: Option<&Ident>) -> TokenStream2
             for route in route_group.routes {
                 let method = Ident::new(route.method, Span::call_site());
                 let req_data = Ident::new(route.req_data, Span::call_site());
-                let r = match cacher {
+                let r = match cache_type {
                     Some(cacher) => build_cached_route(
                         server_type,
                         &api,

--- a/mentat/src/lib.rs
+++ b/mentat/src/lib.rs
@@ -32,7 +32,13 @@ mod server_rexport {
         };
         pub use tracing::Instrument;
 
-        pub use super::{api::*, cache::Cache, conf::Configuration, server::RpcCaller, *};
+        pub use super::{
+            api::*,
+            cache::Cache,
+            conf::Configuration,
+            server::{RpcCaller, Server},
+            *,
+        };
         pub use crate::requests::*;
     }
 }

--- a/mentat/src/server/mod.rs
+++ b/mentat/src/server/mod.rs
@@ -33,10 +33,6 @@ pub trait ServerType: Sized + 'static {
         let path = std::path::PathBuf::from(&args[1]);
         Configuration::load(&path)
     }
-
-    fn build_server() -> Server<Self> {
-        Server::default()
-    }
 }
 
 pub struct ServerBuilder<Types: ServerType> {

--- a/rosetta-snarkos/src/main.rs
+++ b/rosetta-snarkos/src/main.rs
@@ -7,7 +7,10 @@ mod node;
 mod request;
 mod responses;
 
-use mentat::{cache::DefaultCacheInner, server::ServerType};
+use mentat::{
+    cache::DefaultCacheInner,
+    server::{Server, ServerType},
+};
 
 #[derive(Clone)]
 struct MentatSnarkos;
@@ -20,7 +23,8 @@ impl ServerType for MentatSnarkos {
     type IndexerApi = indexer_api::SnarkosIndexerApi;
 }
 
-#[mentat::main(MentatSnarkos, DefaultCacheInner)]
-async fn main() {
+#[mentat::main(DefaultCacheInner)]
+async fn main() -> Server<MentatSnarkos> {
     println!("hello rosetta!");
+    Server::default()
 }


### PR DESCRIPTION
this change aims to remove the redundancy around the `ServerType::build_server` method and the `main` macro.

`build_server` has been removed and the `main` macro has been changed to operate more like rockets `launch` macro. it allows you to build a server instance inside the main function that will get passed onto mentat and used during route generation/server execution.

its worth noting that this changes the usage and syntax of the main macro, it no longer takes ServerType as a macro argument, instead parsing it from the return type of the function. so its usage now looks like this:

``` rust
#[derive(Clone)]
struct MentatSnarkos;

impl ServerType for MentatSnarkos {
    type CallApi = call_api::SnarkosCallApi;
    type ConstructionApi = construction_api::SnarkosConstructionApi;
    type CustomConfig = node::NodeConfig;
    type DataApi = data_api::SnarkosDataApi;
    type IndexerApi = indexer_api::SnarkosIndexerApi;
}

#[mentat::main(DefaultCacheInner)]
async fn main() -> Server<MentatSnarkos> {
    println!("hello rosetta!");
    Server::default()
}
```

the `mentat` macro still functions the same on the users end, but under the hood it calls `Server::default` instead of `build_server`. now if the user ever requires a non-default instance, they can just use the `main` macro

this pr also contains a cleanup to the errors emitted by the `main` macro, and adds some documentation in the mentat-macros crate. this *should* be the last major change to the proc macro's for the foreseeable future, as i think this change gives us all the functionality a user would need when constructing the main function.