### PR TITLE
[Feature] Simple Bitcoin regtest config

### DIFF
--- a/rosetta-bitcoin/README.md
+++ b/rosetta-bitcoin/README.md
@@ -1,0 +1,13 @@
+# Mentat Bitcoin Rosetta Implementation
+
+## Running
+
+### Regtest Node
+
+Running this regtest bitcoin example requires `docker` and uses docker for the running the node.
+
+This node is setup for you and works out of the box.
+
+Start the rosetta-bitcoin with: `cargo run -- regtest.toml`
+
+While this is running, you can generate a "wallet_1" with `./regtest/node_bootstrap.sh`

--- a/rosetta-bitcoin/regtest.toml
+++ b/rosetta-bitcoin/regtest.toml
@@ -1,0 +1,15 @@
+address = "0.0.0.0"
+blockchain = "Bitcoin"
+mode = "Online"
+network = "regtest"
+secure_http = false
+node_address = "127.0.0.1"
+node_path = "./regtest/node.sh"
+node_rpc_port = 8332
+port = 8080
+
+# custom arguments are not passed to docker via node.sh at the moment
+[custom]
+user = "bitcoin"
+pass = "password"
+data_dir = "/bitcoin/.bitcoin"

--- a/rosetta-bitcoin/regtest/.gitignore
+++ b/rosetta-bitcoin/regtest/.gitignore
@@ -1,0 +1,1 @@
+regtest_data/

--- a/rosetta-bitcoin/regtest/bitcoin.conf
+++ b/rosetta-bitcoin/regtest/bitcoin.conf
@@ -1,0 +1,14 @@
+printtoconsole=1
+dnsseed=0
+upnp=0
+fastprune=1
+regtest=1
+
+[regtest]
+rpcuser=bitcoin
+rpcpassword=password
+rpcbind=127.0.0.1
+rpcallowip=::/0
+
+[rpc]
+server=1

--- a/rosetta-bitcoin/regtest/node.sh
+++ b/rosetta-bitcoin/regtest/node.sh
@@ -1,0 +1,13 @@
+#!/usr/bin/env bash
+
+SELF=$(readlink -f "$0")
+BASEDIR=$(dirname "$SELF")
+
+mkdir -p $BASEDIR/regtest_data
+
+docker run -t --rm \
+  -p 8332:8332 \
+  -v "$BASEDIR/regtest_data:/bitcoin/.bitcoin" \
+  -v "$BASEDIR/bitcoin.conf:/bitcoin/.bitcoin/bitcoin.conf" \
+  --name bitcoin_regtest \
+  kylemanna/bitcoind

--- a/rosetta-bitcoin/regtest/node_bash.sh
+++ b/rosetta-bitcoin/regtest/node_bash.sh
@@ -1,0 +1,3 @@
+#!/usr/bin/env bash
+# run bash scripts on the regtest node
+docker exec -i bitcoin_regtest su bitcoin -c bash

--- a/rosetta-bitcoin/regtest/node_bootstrap.sh
+++ b/rosetta-bitcoin/regtest/node_bootstrap.sh
@@ -1,0 +1,10 @@
+#!/usr/bin/env bash
+
+# setup test wallets
+cat <<SCRIPT | $(dirname $0)/node_bash.sh
+if [ ! -d "/bitcoin/.bitcoin/regtest/wallets/wallet_1" ]; then
+  bitcoin-cli createwallet "wallet_1"
+  bitcoin-cli getnewaddress
+  bitcoin-cli -generate -rpcwallet=wallet_1 100 >/dev/null
+fi
+SCRIPT


### PR DESCRIPTION
Time: 1 hour

Related, but not a solution to #62 

For a test environment other than SnarkOS, this PR provides a `regtest.toml` config for a private test blockchain.

More instructions are included in the `rosetta-bitcoin/README.md` (can expand more later)

To start it run `cargo run -- regtest.toml` inside `rosetta-bitcoin`. The config's "node_path" points to a shell script that launches a container running bitcoind. The container provides rosetta-bitcoin with an exposed bitcoin JSON-RPC endpoint.

