### PR TITLE
[Feature] Skip serde serialize on models based on rosetta-sdk-go

### DIFF
--- a/mentat/src/errors/mod.rs
+++ b/mentat/src/errors/mod.rs
@@ -15,9 +15,11 @@ use crate::api::MentatResponse;
 pub struct ApiError {
     pub code: u16,
     pub message: String,
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub description: Option<String>,
     pub retriable: bool,
     #[serde(default)]
+    #[serde(skip_serializing_if = "IndexMap::is_empty")]
     pub details: IndexMap<String, Value>,
 }
 

--- a/mentat/src/misc/peer.rs
+++ b/mentat/src/misc/peer.rs
@@ -7,5 +7,6 @@ use super::*;
 pub struct Peer {
     pub peer_id: String,
     #[serde(default)]
+    #[serde(skip_serializing_if = "IndexMap::is_empty")]
     pub metadata: IndexMap<String, Value>,
 }

--- a/mentat/src/misc/sync_status.rs
+++ b/mentat/src/misc/sync_status.rs
@@ -14,11 +14,14 @@ pub struct SyncStatus {
     /// all indices up to and including current_block_identifier in
     /// NetworkStatusResponse must be queryable via the /block endpoint
     /// (excluding indices less than oldest_block_identifier).
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub current_index: Option<u64>,
     /// TargetIndex is the index of the block that the implementation is
     /// attempting to sync to in the current stage.
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub target_index: Option<u64>,
     /// Stage is the phase of the sync process.
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub stage: Option<String>,
     /// sycned is a boolean that indicates if an implementation has synced up to
     /// the most recent block. If this field is not populated, the caller should
@@ -28,5 +31,6 @@ pub struct SyncStatus {
     /// transactions). In these blockchains, the most recent block could have a
     /// timestamp far behind the current time but the node could be healthy and
     /// at tip.
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub synced: Option<bool>,
 }

--- a/mentat/src/misc/version.rs
+++ b/mentat/src/misc/version.rs
@@ -16,9 +16,11 @@ pub struct Version {
     /// When a middleware server is used to adhere to the Rosetta interface, it
     /// should return its version here. This can help clients manage
     /// deployments.
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub middleware_version: Option<String>,
     /// Any other information that may be useful about versioning of dependent
     /// services should be returned here.
     #[serde(default)]
+    #[serde(skip_serializing_if = "IndexMap::is_empty")]
     pub metadata: IndexMap<String, Value>,
 }

--- a/mentat/src/models/allow.rs
+++ b/mentat/src/models/allow.rs
@@ -28,6 +28,7 @@ pub struct Allow {
     /// when the genesis block (or blocks) of a network have timestamp 0. If not
     /// populated, block timestamps are assumed to be valid for all available
     /// blocks.
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub timestamp_start_index: Option<u64>,
     /// All methods that are supported by the /call endpoint. Communicating
     /// which parameters should be provided to /call is the responsibility of

--- a/mentat/src/models/balance_exemption.rs
+++ b/mentat/src/models/balance_exemption.rs
@@ -17,10 +17,12 @@ pub struct BalanceExemption {
     /// SubAccountAddress is the SubAccountIdentifier.Address that the
     /// BalanceExemption applies to (regardless of the value of
     /// SubAccountIdentifier.Metadata).
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub sub_account_address: Option<String>,
     /// Currency is composed of a canonical Symbol and Decimals. This Decimals
     /// value is used to convert an Amount.Value from atomic units (Satoshis) to
     /// standard units (Bitcoins).
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub currency: Option<Currency>,
     /// ExemptionType is used to indicate if the live balance for an account
     /// subject to a BalanceExemption could increase above, decrease below, or
@@ -32,5 +34,6 @@ pub struct BalanceExemption {
     /// dynamic: The live balance may increase above, decrease below, or equal
     /// the computed balance. This typically occurs with tokens that have a
     /// dynamic supply.
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub exemption_type: Option<ExemptionType>,
 }

--- a/mentat/src/models/related_transaction.rs
+++ b/mentat/src/models/related_transaction.rs
@@ -7,6 +7,7 @@ use super::*;
 pub struct RelatedTransaction {
     /// The network_identifier specifies which network a particular object is
     /// associated with.
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub network_identifier: Option<NetworkIdentifier>,
     /// The transaction_identifier uniquely identifies a transaction in a
     /// particular network and block or in the mempool.

--- a/mentat/src/models/signing_payload.rs
+++ b/mentat/src/models/signing_payload.rs
@@ -8,12 +8,15 @@ use super::*;
 pub struct SigningPayload {
     /// [DEPRECATED by account_identifier in v1.4.4] The network-specific
     /// address of the account that should sign the payload.
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub address: Option<String>,
     /// The account_identifier uniquely identifies an account within a network.
     /// All fields in the account_identifier are utilized to determine this
     /// uniqueness (including the metadata field, if populated).
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub account_identifier: Option<AccountIdentifier>,
     pub hex_bytes: String,
     /// SignatureType is the type of a cryptographic signature.
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub signature_type: Option<SignatureType>,
 }

--- a/mentat/src/models/transaction.rs
+++ b/mentat/src/models/transaction.rs
@@ -16,5 +16,6 @@ pub struct Transaction {
     /// transaction) should include the tranaction_identifier of these
     /// transactions in the metadata.
     #[serde(default)]
+    #[serde(skip_serializing_if = "IndexMap::is_empty")]
     pub metadata: IndexMap<String, Value>,
 }

--- a/mentat/src/requests/account_balance.rs
+++ b/mentat/src/requests/account_balance.rs
@@ -15,10 +15,12 @@ pub struct AccountBalanceRequest {
     /// When fetching data by BlockIdentifier, it may be possible to only
     /// specify the index or hash. If neither property is specified, it is
     /// assumed that the client is making a request at the current block.
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub block_identifier: Option<PartialBlockIdentifier>,
     /// In some cases, the caller may not want to retrieve all available
     /// balances for an AccountIdentifier. If the currencies field is populated,
     /// only balances for the specified currencies will be returned. If not
     /// populated, all available balances will be returned.
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub currencies: Option<Vec<Currency>>,
 }

--- a/mentat/src/requests/account_coins.rs
+++ b/mentat/src/requests/account_coins.rs
@@ -19,5 +19,6 @@ pub struct AccountCoinsRequest {
     /// balances for an AccountIdentifier. If the currencies field is populated,
     /// only balances for the specified currencies will be returned. If not
     /// populated, all available balances will be returned.
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub currencies: Option<Vec<Currency>>,
 }

--- a/mentat/src/requests/construction_metadata.rs
+++ b/mentat/src/requests/construction_metadata.rs
@@ -18,6 +18,8 @@ pub struct ConstructionMetadataRequest {
     /// construction (which may require multiple node fetches), the client can
     /// populate an options object to limit the metadata returned to only the
     /// subset required.
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub options: Option<Value>,
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub public_keys: Option<Vec<PublicKey>>,
 }

--- a/mentat/src/requests/construction_payloads.rs
+++ b/mentat/src/requests/construction_payloads.rs
@@ -14,6 +14,8 @@ pub struct ConstructionPayloadsRequest {
     pub network_identifier: NetworkIdentifier,
     pub operations: Vec<Operation>,
     #[serde(default)]
+    #[serde(skip_serializing_if = "IndexMap::is_empty")]
     pub metadata: IndexMap<String, Value>,
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub public_keys: Option<Vec<PublicKey>>,
 }

--- a/mentat/src/requests/construction_preprocess.rs
+++ b/mentat/src/requests/construction_preprocess.rs
@@ -26,7 +26,10 @@ pub struct ConstructionPreprocessRequest {
     pub network_identifier: NetworkIdentifier,
     pub operations: Vec<Operation>,
     #[serde(default)]
+    #[serde(skip_serializing_if = "IndexMap::is_empty")]
     pub metadata: IndexMap<String, Value>,
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub max_fee: Option<Vec<Amount>>,
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub suggested_fee_multiplier: Option<f64>,
 }

--- a/mentat/src/requests/event_blocks.rs
+++ b/mentat/src/requests/event_blocks.rs
@@ -10,8 +10,10 @@ pub struct EventsBlocksRequest {
     /// offset is the offset into the event stream to sync events from. If this
     /// field is not populated, we return the limit events backwards from tip.
     /// If this is set to 0, we start from the beginning.
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub offset: Option<u64>,
     /// limit is the maximum number of events to fetch in one call. The
     /// implementation may return "= limit events.
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub limit: Option<u64>,
 }

--- a/mentat/src/requests/metadata.rs
+++ b/mentat/src/requests/metadata.rs
@@ -7,5 +7,6 @@ use super::*;
 #[derive(Serialize, Deserialize, Debug, Default)]
 pub struct MetadataRequest {
     #[serde(default)]
+    #[serde(skip_serializing_if = "IndexMap::is_empty")]
     pub metadata: IndexMap<String, Value>,
 }

--- a/mentat/src/requests/search_transactions.rs
+++ b/mentat/src/requests/search_transactions.rs
@@ -10,34 +10,43 @@ pub struct SearchTransactionsRequest {
     /// Operator is used by query-related endpoints to determine how to apply
     /// conditions. If this field is not populated, the default and value will
     /// be used.
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub operator: Option<Operator>,
     /// max_block is the largest block index to consider when searching for
     /// transactions. If this field is not populated, the current block is
     /// considered the max_block. If you do not specify a max_block, it is
     /// possible a newly synced block will interfere with paginated transaction
     /// queries (as the offset could become invalid with newly added rows).
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub max_block: Option<u64>,
     /// offset is the offset into the query result to start returning
     /// transactions. If any search conditions are changed, the query offset
     /// will change and you must restart your search iteration.
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub offset: Option<u64>,
     /// limit is the maximum number of transactions to return in one call. The
     /// implementation may return "= limit transactions.
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub limit: Option<u64>,
     /// The transaction_identifier uniquely identifies a transaction in a
     /// particular network and block or in the mempool.
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub transaction_identifier: Option<TransactionIdentifier>,
     /// The account_identifier uniquely identifies an account within a network.
     /// All fields in the account_identifier are utilized to determine this
     /// uniqueness (including the metadata field, if populated).
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub account_identifier: Option<AccountIdentifier>,
     /// CoinIdentifier uniquely identifies a Coin.
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub coin_identifier: Option<CoinIdentifier>,
     /// Currency is composed of a canonical Symbol and Decimals. This Decimals
     /// value is used to convert an Amount.Value from atomic units (Satoshis) to
     /// standard units (Bitcoins).
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub currency: Option<Currency>,
     /// status is the network-specific operation type.
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub status: Option<String>,
     /// type is the network-specific operation type.
     #[serde(rename = "type")]
@@ -45,8 +54,10 @@ pub struct SearchTransactionsRequest {
     /// address is AccountIdentifier.Address. This is used to get all
     /// transactions related to an AccountIdentifier.Address, regardless of
     /// SubAccountIdentifier.
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub address: Option<String>,
     /// success is a synthetic condition populated by parsing network-specific
     /// operation statuses (using the mapping provided in /network/options).
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub success: Option<bool>,
 }

--- a/mentat/src/responses/account_balance.rs
+++ b/mentat/src/responses/account_balance.rs
@@ -18,5 +18,6 @@ pub struct AccountBalanceResponse {
     /// include that number in the metadata. This number could be unique to the
     /// identifier or global across the account address.
     #[serde(default)]
+    #[serde(skip_serializing_if = "IndexMap::is_empty")]
     pub metadata: IndexMap<String, Value>,
 }

--- a/mentat/src/responses/account_coins.rs
+++ b/mentat/src/responses/account_coins.rs
@@ -22,5 +22,6 @@ pub struct AccountCoinsResponse {
     /// number in the metadata. This number could be unique to the identifier or
     /// global across the account address.
     #[serde(default)]
+    #[serde(skip_serializing_if = "IndexMap::is_empty")]
     pub metadata: IndexMap<String, Value>,
 }

--- a/mentat/src/responses/block.rs
+++ b/mentat/src/responses/block.rs
@@ -17,6 +17,7 @@ pub struct BlockResponse {
     /// requested and received a block identified by a specific
     /// BlockIndentifier, all future calls for that same BlockIdentifier must
     /// return the same block contents.
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub block: Option<Block>,
     /// Some blockchains may require additional transactions to be fetched that
     /// weren't returned in the block response (ex: block only returns

--- a/mentat/src/responses/construction_derive.rs
+++ b/mentat/src/responses/construction_derive.rs
@@ -7,11 +7,14 @@ use super::*;
 pub struct ConstructionDeriveResponse {
     /// [DEPRECATED by account_identifier in v1.4.4] Address in network-specific
     /// format.
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub address: Option<String>,
     /// The account_identifier uniquely identifies an account within a network.
     /// All fields in the account_identifier are utilized to determine this
     /// uniqueness (including the metadata field, if populated).
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub account_identifier: Option<AccountIdentifier>,
     #[serde(default)]
+    #[serde(skip_serializing_if = "IndexMap::is_empty")]
     pub metadata: IndexMap<String, Value>,
 }

--- a/mentat/src/responses/construction_metadata.rs
+++ b/mentat/src/responses/construction_metadata.rs
@@ -12,5 +12,6 @@ use super::*;
 #[derive(Clone, Serialize, Deserialize, Debug, Default)]
 pub struct ConstructionMetadataResponse {
     pub metadata: IndexMap<String, Value>,
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub suggested_fee: Option<Vec<Amount>>,
 }

--- a/mentat/src/responses/construction_parse.rs
+++ b/mentat/src/responses/construction_parse.rs
@@ -11,8 +11,11 @@ pub struct ConstructionParseResponse {
     /// [DEPRECATED by account_identifier_signers in v1.4.4] All signers
     /// (addresses) of a particular transaction. If the transaction is unsigned,
     /// it should be empty.
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub signers: Option<Vec<String>>,
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub account_identifier_signers: Option<Vec<AccountIdentifier>>,
     #[serde(default)]
+    #[serde(skip_serializing_if = "IndexMap::is_empty")]
     pub metadata: IndexMap<String, Value>,
 }

--- a/mentat/src/responses/construction_preprocess.rs
+++ b/mentat/src/responses/construction_preprocess.rs
@@ -15,6 +15,8 @@ pub struct ConstructionPreprocessResponse {
     /// The options that will be sent directly to /construction/metadata by the
     /// caller.
     #[serde(default)]
+    #[serde(skip_serializing_if = "IndexMap::is_empty")]
     pub options: IndexMap<String, Value>,
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub required_public_keys: Option<Vec<AccountIdentifier>>,
 }

--- a/mentat/src/responses/mempool_transaction.rs
+++ b/mentat/src/responses/mempool_transaction.rs
@@ -11,5 +11,6 @@ pub struct MempoolTransactionResponse {
     /// same TransactionIdentifier.
     pub transaction: Transaction,
     #[serde(default)]
+    #[serde(skip_serializing_if = "IndexMap::is_empty")]
     pub metadata: IndexMap<String, Value>,
 }

--- a/mentat/src/responses/network_status.rs
+++ b/mentat/src/responses/network_status.rs
@@ -26,12 +26,14 @@ pub struct NetworkStatusResponse {
     pub genesis_block_identifier: BlockIdentifier,
     /// The block_identifier uniquely identifies a block in a particular
     /// network.
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub oldest_block_identifier: Option<BlockIdentifier>,
     /// SyncStatus is used to provide additional context about an
     /// implementation's sync status. This object is often used by
     /// implementations to indicate healthiness when block data cannot be
     /// queried until some sync phase completes or cannot be determined by
     /// comparing the timestamp of the most recent block with the current time.
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub sync_status: Option<SyncStatus>,
     pub peers: Vec<Peer>,
 }

--- a/mentat/src/responses/search_transactions.rs
+++ b/mentat/src/responses/search_transactions.rs
@@ -18,5 +18,6 @@ pub struct SearchTransactionsResponse {
     /// next_offset is the next offset to use when paginating through
     /// transaction results. If this field is not populated, there are no more
     /// transactions to query.
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub next_offset: Option<u64>,
 }


### PR DESCRIPTION
Adds an equivalent to Go's "omitempty" (`#[serde(skip_serializing_if = "Option::is_none")]`) to Mentat's models based on [Rosetta Go SDK Types](https://github.com/coinbase/rosetta-sdk-go/tree/master/types).

Time: 30 minutes