### PR TITLE
map_err_mentat

### DIFF
--- a/mentat/src/api/optional.rs
+++ b/mentat/src/api/optional.rs
@@ -2,12 +2,11 @@
 //! These traits are easily overridable for custom
 //! implementations.
 
-use crate::errors::MapErrMentat;
 use axum::async_trait;
 use sysinfo::{Pid, ProcessExt, System, SystemExt};
 
 use super::*;
-use crate::conf::NodePid;
+use crate::{conf::NodePid, errors::MapErrMentat};
 
 #[axum::async_trait]
 /// The `OptionalApi` Trait.

--- a/mentat/src/api/optional.rs
+++ b/mentat/src/api/optional.rs
@@ -2,7 +2,7 @@
 //! These traits are easily overridable for custom
 //! implementations.
 
-use crate::errors::IntoMentat;
+use crate::errors::MapErrMentat;
 use axum::async_trait;
 use sysinfo::{Pid, ProcessExt, System, SystemExt};
 
@@ -34,7 +34,7 @@ pub trait OptionalApi: Clone + Default {
     async fn usage(&self, process: &str, system: &System, pid: Pid) -> Result<Usage> {
         let proc = system
             .process(pid)
-            .unwrap_or_mentat(|| format!("Could not find `{process}` process pid: `{pid}`."))?;
+            .map_err_mentat(|| format!("Could not find `{process}` process pid: `{pid}`."))?;
         let total_cpu_usage = proc.cpu_usage();
         Ok(Usage {
             cpu_usage: (total_cpu_usage / num_cpus::get() as f32),

--- a/mentat/src/api/optional.rs
+++ b/mentat/src/api/optional.rs
@@ -33,7 +33,7 @@ pub trait OptionalApi: Clone + Default {
     async fn usage(&self, process: &str, system: &System, pid: Pid) -> Result<Usage> {
         let proc = system
             .process(pid)
-            .map_err_mentat(|| format!("Could not find `{process}` process pid: `{pid}`."))?;
+            .merr(|| format!("Could not find `{process}` process pid: `{pid}`."))?;
         let total_cpu_usage = proc.cpu_usage();
         Ok(Usage {
             cpu_usage: (total_cpu_usage / num_cpus::get() as f32),

--- a/mentat/src/api/optional.rs
+++ b/mentat/src/api/optional.rs
@@ -2,6 +2,7 @@
 //! These traits are easily overridable for custom
 //! implementations.
 
+use crate::errors::IntoMentat;
 use axum::async_trait;
 use sysinfo::{Pid, ProcessExt, System, SystemExt};
 
@@ -31,9 +32,9 @@ pub trait OptionalApi: Clone + Default {
 
     /// A method for getting the usage of a Process.
     async fn usage(&self, process: &str, system: &System, pid: Pid) -> Result<Usage> {
-        let proc = system.process(pid).ok_or(MentatError::from(format!(
-            "Could not find `{process}` process pid: `{pid}`."
-        )))?;
+        let proc = system
+            .process(pid)
+            .unwrap_or_mentat(|| format!("Could not find `{process}` process pid: `{pid}`."))?;
         let total_cpu_usage = proc.cpu_usage();
         Ok(Usage {
             cpu_usage: (total_cpu_usage / num_cpus::get() as f32),

--- a/mentat/src/cache/cache_struct.rs
+++ b/mentat/src/cache/cache_struct.rs
@@ -99,6 +99,6 @@ where
         };
 
         // waiting for in progress request
-        rx.recv().await.map_err_mentat(|e| e)?
+        rx.recv().await.merr(|e| e)?
     }
 }

--- a/mentat/src/cache/cache_struct.rs
+++ b/mentat/src/cache/cache_struct.rs
@@ -11,7 +11,7 @@ use std::{
 use tokio::sync::{broadcast, Mutex};
 
 use super::CacheInner;
-use crate::{api::MentatResponse, errors::IntoMentat};
+use crate::{api::MentatResponse, errors::MapErrMentat};
 
 /// A type to represent a async closure with some output.
 pub type BoxFut<'a, O> = Pin<Box<dyn Future<Output = O> + Send + 'a>>;
@@ -99,6 +99,6 @@ where
         };
 
         // waiting for in progress request
-        rx.recv().await.unwrap_or_mentat(|e| e)?
+        rx.recv().await.map_err_mentat(|e| e)?
     }
 }

--- a/mentat/src/cache/cache_struct.rs
+++ b/mentat/src/cache/cache_struct.rs
@@ -11,7 +11,7 @@ use std::{
 use tokio::sync::{broadcast, Mutex};
 
 use super::CacheInner;
-use crate::{api::MentatResponse, errors::MentatError};
+use crate::{api::MentatResponse, errors::IntoMentat};
 
 /// A type to represent a async closure with some output.
 pub type BoxFut<'a, O> = Pin<Box<dyn Future<Output = O> + Send + 'a>>;
@@ -99,6 +99,6 @@ where
         };
 
         // waiting for in progress request
-        rx.recv().await.map_err(MentatError::from)?
+        rx.recv().await.unwrap_or_mentat(|e| e)?
     }
 }

--- a/mentat/src/errors/server_error.rs
+++ b/mentat/src/errors/server_error.rs
@@ -117,7 +117,8 @@ impl IntoResponse for MentatError {
 pub trait MapErrMentat<F> {
     /// the type to return
     type T;
-    /// like unwrap_or_else except just returns a mentat error using the given string
+    /// like unwrap_or_else except just returns a mentat error using the given
+    /// string
     fn map_err_mentat(self, err: F) -> Result<Self::T, MentatError>;
 }
 

--- a/mentat/src/errors/server_error.rs
+++ b/mentat/src/errors/server_error.rs
@@ -113,5 +113,35 @@ impl IntoResponse for MentatError {
     }
 }
 
+/// allows you to easily return a MentatError instead of a none/err
+pub trait IntoMentat<F> {
+    /// the type to return
+    type T;
+    /// like unwrap_or_else except just returns a mentat error using the given string
+    fn unwrap_or_mentat(self, err: F) -> Result<Self::T, MentatError>;
+}
+
+impl<T, O: Display, F: FnOnce() -> O> IntoMentat<F> for Option<T> {
+    type T = T;
+
+    fn unwrap_or_mentat(self, err: F) -> Result<Self::T, MentatError> {
+        match self {
+            Some(t) => Ok(t),
+            None => Err(MentatError::from(err())),
+        }
+    }
+}
+
+impl<T, E, O: Display, F: FnOnce(E) -> O> IntoMentat<F> for Result<T, E> {
+    type T = T;
+
+    fn unwrap_or_mentat(self, err: F) -> Result<Self::T, MentatError> {
+        match self {
+            Ok(t) => Ok(t),
+            Err(e) => Err(MentatError::from(err(e))),
+        }
+    }
+}
+
 /// The Result type for Mentat to always return a `MentatError`.
 pub type Result<T, E = MentatError> = std::result::Result<T, E>;

--- a/mentat/src/errors/server_error.rs
+++ b/mentat/src/errors/server_error.rs
@@ -117,7 +117,8 @@ impl IntoResponse for MentatError {
 pub trait MapErrMentat<F> {
     /// the type to return
     type T;
-    /// like `map_err` except returns a mentat error containing the output of the given closure as a string
+    /// like `map_err` except returns a mentat error containing the output of
+    /// the given closure as a string
     fn map_err_mentat(self, err: F) -> Result<Self::T, MentatError>;
 }
 

--- a/mentat/src/errors/server_error.rs
+++ b/mentat/src/errors/server_error.rs
@@ -114,17 +114,17 @@ impl IntoResponse for MentatError {
 }
 
 /// allows you to easily return a MentatError instead of a none/err
-pub trait IntoMentat<F> {
+pub trait MapErrMentat<F> {
     /// the type to return
     type T;
     /// like unwrap_or_else except just returns a mentat error using the given string
-    fn unwrap_or_mentat(self, err: F) -> Result<Self::T, MentatError>;
+    fn map_err_mentat(self, err: F) -> Result<Self::T, MentatError>;
 }
 
-impl<T, O: Display, F: FnOnce() -> O> IntoMentat<F> for Option<T> {
+impl<T, O: Display, F: FnOnce() -> O> MapErrMentat<F> for Option<T> {
     type T = T;
 
-    fn unwrap_or_mentat(self, err: F) -> Result<Self::T, MentatError> {
+    fn map_err_mentat(self, err: F) -> Result<Self::T, MentatError> {
         match self {
             Some(t) => Ok(t),
             None => Err(MentatError::from(err())),
@@ -132,10 +132,10 @@ impl<T, O: Display, F: FnOnce() -> O> IntoMentat<F> for Option<T> {
     }
 }
 
-impl<T, E, O: Display, F: FnOnce(E) -> O> IntoMentat<F> for Result<T, E> {
+impl<T, E, O: Display, F: FnOnce(E) -> O> MapErrMentat<F> for Result<T, E> {
     type T = T;
 
-    fn unwrap_or_mentat(self, err: F) -> Result<Self::T, MentatError> {
+    fn map_err_mentat(self, err: F) -> Result<Self::T, MentatError> {
         match self {
             Ok(t) => Ok(t),
             Err(e) => Err(MentatError::from(err(e))),

--- a/mentat/src/errors/server_error.rs
+++ b/mentat/src/errors/server_error.rs
@@ -119,13 +119,13 @@ pub trait MapErrMentat<F> {
     type T;
     /// like `map_err` except returns a mentat error containing the output of
     /// the given closure as a string
-    fn map_err_mentat(self, err: F) -> Result<Self::T, MentatError>;
+    fn merr(self, err: F) -> Result<Self::T, MentatError>;
 }
 
 impl<T, O: Display, F: FnOnce() -> O> MapErrMentat<F> for Option<T> {
     type T = T;
 
-    fn map_err_mentat(self, err: F) -> Result<Self::T, MentatError> {
+    fn merr(self, err: F) -> Result<Self::T, MentatError> {
         match self {
             Some(t) => Ok(t),
             None => Err(MentatError::from(err())),
@@ -136,7 +136,7 @@ impl<T, O: Display, F: FnOnce() -> O> MapErrMentat<F> for Option<T> {
 impl<T, E, O: Display, F: FnOnce(E) -> O> MapErrMentat<F> for Result<T, E> {
     type T = T;
 
-    fn map_err_mentat(self, err: F) -> Result<Self::T, MentatError> {
+    fn merr(self, err: F) -> Result<Self::T, MentatError> {
         match self {
             Ok(t) => Ok(t),
             Err(e) => Err(MentatError::from(err(e))),

--- a/mentat/src/errors/server_error.rs
+++ b/mentat/src/errors/server_error.rs
@@ -117,8 +117,7 @@ impl IntoResponse for MentatError {
 pub trait MapErrMentat<F> {
     /// the type to return
     type T;
-    /// like unwrap_or_else except just returns a mentat error using the given
-    /// string
+    /// like `map_err` except returns a mentat error containing the output of the given closure as a string
     fn map_err_mentat(self, err: F) -> Result<Self::T, MentatError>;
 }
 

--- a/mentat/src/identifiers/network_identifier.rs
+++ b/mentat/src/identifiers/network_identifier.rs
@@ -8,7 +8,7 @@ use crate::requests::NetworkRequest;
 #[cfg(feature = "server")]
 use crate::{
     conf::{Configuration, Network, NodeConf},
-    errors::{MentatError, Result},
+    errors::{Result},
     server::ServerType,
 };
 
@@ -81,17 +81,19 @@ impl NetworkIdentifier {
             if network_identifier.blockchain.to_uppercase()
                 != Types::CustomConfig::BLOCKCHAIN.to_uppercase()
             {
-                return Err(MentatError::from(format!(
+                return Err(format!(
                     "invalid blockchain ID: found `{}`, expected `{}`",
                     network_identifier.blockchain.to_uppercase(),
                     Types::CustomConfig::BLOCKCHAIN.to_uppercase()
-                )));
+                )
+                .into());
             } else if Network::from(network_identifier.network.to_uppercase()) != config.network {
-                return Err(MentatError::from(format!(
+                return Err(format!(
                     "invalid network ID: found `{}`, expected `{}`",
                     network_identifier.network.to_uppercase(),
                     config.network
-                )));
+                )
+                .into());
             }
         }
         Ok(())

--- a/mentat/src/identifiers/network_identifier.rs
+++ b/mentat/src/identifiers/network_identifier.rs
@@ -8,7 +8,7 @@ use crate::requests::NetworkRequest;
 #[cfg(feature = "server")]
 use crate::{
     conf::{Configuration, Network, NodeConf},
-    errors::{Result},
+    errors::Result,
     server::ServerType,
 };
 

--- a/mentat/src/server/middleware_checks.rs
+++ b/mentat/src/server/middleware_checks.rs
@@ -17,7 +17,7 @@ pub async fn middleware_checks<Types: ServerType>(
     let req = if matches!(body.size_hint().exact(), Some(s) if s != 0) {
         let extensions = &parts.extensions;
         let bytes = hyper::body::to_bytes(body).await?;
-        let json = serde_json::from_slice::<Value>(&bytes).map_err_mentat(|e| e)?;
+        let json = serde_json::from_slice::<Value>(&bytes).merr(|e| e)?;
         Types::middleware_checks(extensions, &json)?;
         Request::from_parts(parts, Body::from(bytes))
     } else {

--- a/mentat/src/server/middleware_checks.rs
+++ b/mentat/src/server/middleware_checks.rs
@@ -5,7 +5,7 @@ use hyper::{Body, Request};
 use serde_json::Value;
 
 use super::ServerType;
-use crate::errors::{MentatError, Result};
+use crate::errors::{IntoMentat, Result};
 
 /// A function to do all middleware checks.
 pub async fn middleware_checks<Types: ServerType>(
@@ -17,7 +17,7 @@ pub async fn middleware_checks<Types: ServerType>(
     let req = if matches!(body.size_hint().exact(), Some(s) if s != 0) {
         let extensions = &parts.extensions;
         let bytes = hyper::body::to_bytes(body).await?;
-        let json = serde_json::from_slice::<Value>(&bytes).map_err(MentatError::from)?;
+        let json = serde_json::from_slice::<Value>(&bytes).unwrap_or_mentat(|e| e)?;
         Types::middleware_checks(extensions, &json)?;
         Request::from_parts(parts, Body::from(bytes))
     } else {

--- a/mentat/src/server/middleware_checks.rs
+++ b/mentat/src/server/middleware_checks.rs
@@ -5,7 +5,7 @@ use hyper::{Body, Request};
 use serde_json::Value;
 
 use super::ServerType;
-use crate::errors::{IntoMentat, Result};
+use crate::errors::{MapErrMentat, Result};
 
 /// A function to do all middleware checks.
 pub async fn middleware_checks<Types: ServerType>(
@@ -17,7 +17,7 @@ pub async fn middleware_checks<Types: ServerType>(
     let req = if matches!(body.size_hint().exact(), Some(s) if s != 0) {
         let extensions = &parts.extensions;
         let bytes = hyper::body::to_bytes(body).await?;
-        let json = serde_json::from_slice::<Value>(&bytes).unwrap_or_mentat(|e| e)?;
+        let json = serde_json::from_slice::<Value>(&bytes).map_err_mentat(|e| e)?;
         Types::middleware_checks(extensions, &json)?;
         Request::from_parts(parts, Body::from(bytes))
     } else {

--- a/rosetta-bitcoin/src/indexer_api.rs
+++ b/rosetta-bitcoin/src/indexer_api.rs
@@ -62,7 +62,7 @@ impl IndexerApi for BitcoinIndexerApi {
             Err(e) => {
                 return Err(match serde_json::from_str(&e.to_string()) {
                     Ok(s) => MentatError::Internal(s),
-                    Err(_) => MentatError::from(format!("unhandled rosetta-bitcoin error: {}", e)),
+                    Err(_) => format!("unhandled rosetta-bitcoin error: {}", e).into(),
                 });
             }
         };

--- a/rosetta-snarkos/src/data_api.rs
+++ b/rosetta-snarkos/src/data_api.rs
@@ -1,7 +1,6 @@
 use mentat::{
     api::{Caller, CallerDataApi, DataApi, MentatResponse},
     axum::{async_trait, Json},
-    errors::MentatError,
     requests::*,
     responses::*,
     server::RpcCaller,
@@ -33,7 +32,7 @@ impl DataApi for SnarkosDataApi {
                 .await?;
             Ok(Json(result.into()))
         } else {
-            Err(MentatError::from("todo"))
+            Err("todo".into())
         }
     }
 


### PR DESCRIPTION
this adds some generic implementations for `MentatError` that makes error handling easier.  similar to `map_err`, you can now use the method `map_err_mentat` on any `Result<T, E>` or `Option<T>` to map it to a mentat error. 

ie:
```rust
rx.recv().await.map_err_mentat(|e| format!("failed to get response: {e}"))?;
```
or 
```rust
arr.get(1).map_err_mentat(|| "failed to get value")?;
```

i originally planned on naming it `unwrap_or_mentat` but figured `map_err_mentat` was a bit more accurate. although if we wanna go with something shorter im fine with that too.

this isnt super useful on main yet, but on btc-endpoints it turns repetitive error handling like this
```rust
let coins = data
    .metadata
    .get("coins")
    .ok_or_else(|| MentatError::from("no coins provided"))?
    .as_array()
    .ok_or_else(|| MentatError::from("malformed coins field in metadata"))?;
for coin in coins {
    let (txid, vout) = coin
        .get("coin_identifier")
        .ok_or_else(|| MentatError::from("no coin identifier on coin struct"))?
        .as_str()
        .ok_or_else(|| MentatError::from("coin identifier is wrong type"))?
        .split_once(':')
        .ok_or_else(|| MentatError::from("invalid coin identifier format"))?;
    tx.input.push(TxIn {
        previous_output: OutPoint {
            txid: Txid::from_str(txid)
                .map_err(|e| MentatError::from(format!("invalid txid `{txid}`: {e}")))?,
            vout: vout.parse::<u32>()
                .map_err(|e| MentatError::from(format!("invalid vout field `{vout}`: {e}")))?,
        },
        // This gets filled in later in `combine`.
        script_sig: Script::new(),
        sequence: u32::MAX,
        witness: Witness::new(),
    });
}
```
into something a bit less annoying
``` rust
let coins = data
    .metadata
    .get("coins")
    .map_err_mentat(|| "no coins provided")?
    .as_array()
    .map_err_mentat(|| "malformed coins field in metadata")?;
for coin in coins {
    let (txid, vout) = coin
        .get("coin_identifier")
        .map_err_mentat(|| "no coin identifier on coin struct")?
        .as_str()
        .map_err_mentat(|| "coin identifier is wrong type")?
        .split_once(':')
        .map_err_mentat(|| "invalid coin identifier format")?;
    tx.input.push(TxIn {
        previous_output: OutPoint {
            txid: Txid::from_str(txid)
                .map_err_mentat(|e| format!("invalid txid `{txid}`: {e}"))?,
            vout: vout.parse::<u32>()
                .map_err_mentat(|e| format!("invalid vout field `{vout}`: {e}"))?,
        },
        // This gets filled in later in `combine`.
        script_sig: Script::new(),
        sequence: u32::MAX,
        witness: Witness::new(),
    });
}
```