### PR TITLE
Config file generation

### DIFF
--- a/mentat/src/conf/configuration.rs
+++ b/mentat/src/conf/configuration.rs
@@ -154,8 +154,10 @@ where
 {
     /// Loads a configuration file from the supplied path.
     pub fn load(path: &Path) -> Self {
+        let path = path.with_extension("toml");
+
         if path.is_file() {
-            let content = fs::read_to_string(path).unwrap_or_else(|e| {
+            let content = fs::read_to_string(&path).unwrap_or_else(|e| {
                 panic!(
                     "Failed to read config file at path `{}`: {}",
                     path.display(),
@@ -176,7 +178,7 @@ where
 
             config
         } else {
-            Self::create_template(path);
+            Self::create_template(&path);
             println!("created config file `{}`", path.display());
             exit(1);
         }
@@ -184,8 +186,6 @@ where
 
     /// Generates a configuration file and writes it to the supplied path.
     pub fn create_template(path: &Path) {
-        let path = path.with_extension("toml");
-
         if let Some(p) = path.parent() {
             fs::create_dir_all(&p)
                 .unwrap_or_else(|e| panic!("failed to create path `{}`: {}", p.display(), e));

--- a/mentat/src/conf/configuration.rs
+++ b/mentat/src/conf/configuration.rs
@@ -6,7 +6,7 @@ use std::{
     io::{BufRead, BufReader, Read},
     net::Ipv4Addr,
     path::{Path, PathBuf},
-    process::{Command, Stdio},
+    process::{exit, Command, Stdio},
     str::FromStr,
     thread,
 };
@@ -154,34 +154,43 @@ where
 {
     /// Loads a configuration file from the supplied path.
     pub fn load(path: &Path) -> Self {
-        let content = fs::read_to_string(path).unwrap_or_else(|e| {
-            panic!(
-                "Failed to read config file at path `{}`: {}",
-                path.display(),
-                e
-            )
-        });
-        let config: Self = toml::from_str(&content).unwrap_or_else(|e| {
-            panic!(
-                "Failed to parse config file at path `{}`: {}",
-                path.display(),
-                e
-            )
-        });
+        if path.is_file() {
+            let content = fs::read_to_string(path).unwrap_or_else(|e| {
+                panic!(
+                    "Failed to read config file at path `{}`: {}",
+                    path.display(),
+                    e
+                )
+            });
+            let config: Self = toml::from_str(&content).unwrap_or_else(|e| {
+                panic!(
+                    "Failed to parse config file at path `{}`: {}",
+                    path.display(),
+                    e
+                )
+            });
 
-        if !config.node_path.exists() {
-            panic!("Failed to find node at `{}`", config.node_path.display())
+            if !config.node_path.exists() {
+                panic!("Failed to find node at `{}`", config.node_path.display())
+            }
+
+            config
+        } else {
+            Self::create_template(path);
+            println!("created config file `{}`", path.display());
+            exit(1);
         }
-
-        config
     }
 
     /// Generates a configuration file and writes it to the supplied path.
     pub fn create_template(path: &Path) {
-        fs::create_dir_all(path)
-            .unwrap_or_else(|e| panic!("failed to create path `{}`: {}", path.display(), e));
+        let path = path.with_extension("toml");
 
-        let default_config = path.join("default.config.toml");
+        if let Some(p) = path.parent() {
+            fs::create_dir_all(&p)
+                .unwrap_or_else(|e| panic!("failed to create path `{}`: {}", p.display(), e));
+        }
+
         let content = toml::to_string_pretty(&Self::default()).unwrap_or_else(|e| {
             panic!(
                 "Failed to create default toml configuration at `{}`: {}",
@@ -190,7 +199,7 @@ where
             )
         });
 
-        fs::write(&default_config, content).unwrap_or_else(|e| {
+        fs::write(&path, content).unwrap_or_else(|e| {
             panic!(
                 "failed to write to default config `{}`: {}",
                 path.display(),


### PR DESCRIPTION
i realized you couldn't generate a new config file. now if you specify a config file that doesn't exist it will generate one for you then exit with exit code 1. it will also add the `.toml` extension if you didn't, so instead of writing `cargo run -- default.toml` you can just do `cargo run -- default`