### PR TITLE
fixed integer descrepancies between mentat and rosetta models

### DIFF
--- a/crates/mentat-asserter/src/account.rs
+++ b/crates/mentat-asserter/src/account.rs
@@ -7,8 +7,8 @@ use super::*;
 /// `contains_duplicate_currency` returns a boolean indicating
 /// if an array of [`Currency`] contains any duplicate currencies.
 pub fn contains_duplicate_currency<'a>(
-    currencies: &[Option<&'a NullableCurrency>],
-) -> Option<&'a NullableCurrency> {
+    currencies: &[Option<&'a UncheckedCurrency>],
+) -> Option<&'a UncheckedCurrency> {
     let mut seen = HashSet::new();
 
     for currency in currencies.iter() {
@@ -37,7 +37,7 @@ pub fn contains_currency(currencies: &[Currency], currency: &Currency) -> bool {
 /// of [`Amount`] is invalid. It is considered invalid if the same
 /// currency is returned multiple times (these should be
 /// consolidated) or if a [`Amount`] is considered invalid.
-pub fn assert_unique_amounts(amounts: &[Option<NullableAmount>]) -> AssertResult<()> {
+pub fn assert_unique_amounts(amounts: &[Option<UncheckedAmount>]) -> AssertResult<()> {
     let mut seen = HashSet::new();
 
     for amt in amounts.iter().filter_map(|a| a.as_ref()) {
@@ -56,12 +56,12 @@ pub fn assert_unique_amounts(amounts: &[Option<NullableAmount>]) -> AssertResult
 }
 
 /// `account_balance_response` returns an error if the provided
-/// [`NullablePartialBlockIdentifier`] is invalid, if the requestBlock
+/// [`UncheckedPartialBlockIdentifier`] is invalid, if the requestBlock
 /// is not nil and not equal to the response block, or
 /// if the same currency is present in multiple amounts.
 pub fn account_balance_response(
-    request_block: Option<&NullablePartialBlockIdentifier>,
-    response: &NullableAccountBalanceResponse,
+    request_block: Option<&UncheckedPartialBlockIdentifier>,
+    response: &UncheckedAccountBalanceResponse,
 ) -> AssertResult<()> {
     block_identifier(response.block_identifier.as_ref())
         .map_err(|e| format!("{e}: block identifier is invalid"))?;
@@ -95,7 +95,7 @@ pub fn account_balance_response(
 
 /// `account_coins` returns an error if the provided
 /// [`AccountCoinsResponse`] is invalid.
-pub fn account_coins(response: &NullableAccountCoinsResponse) -> AssertResult<()> {
+pub fn account_coins(response: &UncheckedAccountCoinsResponse) -> AssertResult<()> {
     block_identifier(response.block_identifier.as_ref())
         .map_err(|e| format!("{e}: block identifier is invalid"))?;
     coins(&response.coins).map_err(|e| format!("{e}: coins are invalid"))?;

--- a/crates/mentat-asserter/src/account.rs
+++ b/crates/mentat-asserter/src/account.rs
@@ -56,11 +56,11 @@ pub fn assert_unique_amounts(amounts: &[Option<NullableAmount>]) -> AssertResult
 }
 
 /// `account_balance_response` returns an error if the provided
-/// [`PartialBlockIdentifier`] is invalid, if the requestBlock
+/// [`NullablePartialBlockIdentifier`] is invalid, if the requestBlock
 /// is not nil and not equal to the response block, or
 /// if the same currency is present in multiple amounts.
 pub fn account_balance_response(
-    request_block: Option<&PartialBlockIdentifier>,
+    request_block: Option<&NullablePartialBlockIdentifier>,
     response: &NullableAccountBalanceResponse,
 ) -> AssertResult<()> {
     block_identifier(response.block_identifier.as_ref())

--- a/crates/mentat-asserter/src/account_test.rs
+++ b/crates/mentat-asserter/src/account_test.rs
@@ -130,12 +130,12 @@ fn test_contains_duplicate_currency() {
         TestCase {
             name: "simple contains",
             payload: vec![
-                Some(NullableCurrency {
+                Some(UncheckedCurrency {
                     symbol: "BTC".to_string(),
                     decimals: 8,
                     metadata: Default::default(),
                 }),
-                Some(NullableCurrency {
+                Some(UncheckedCurrency {
                     symbol: "BTC".to_string(),
                     decimals: 8,
                     metadata: Default::default(),
@@ -146,12 +146,12 @@ fn test_contains_duplicate_currency() {
         TestCase {
             name: "complex contains",
             payload: vec![
-                Some(NullableCurrency {
+                Some(UncheckedCurrency {
                     symbol: "BTC".to_string(),
                     decimals: 8,
                     metadata: indexmap!("blah".to_string() => json!("hello")),
                 }),
-                Some(NullableCurrency {
+                Some(UncheckedCurrency {
                     symbol: "BTC".to_string(),
                     decimals: 8,
                     metadata: indexmap!("blah".to_string() => json!("hello")),
@@ -162,12 +162,12 @@ fn test_contains_duplicate_currency() {
         TestCase {
             name: "more complex contains",
             payload: vec![
-                Some(NullableCurrency {
+                Some(UncheckedCurrency {
                     symbol: "BTC".to_string(),
                     decimals: 8,
                     metadata: indexmap!("blah2".to_string() => json!("bye"), "blah".to_string() => json!("hello")),
                 }),
-                Some(NullableCurrency {
+                Some(UncheckedCurrency {
                     symbol: "BTC".to_string(),
                     decimals: 8,
                     metadata: indexmap!("blah2".to_string() => json!("bye"), "blah".to_string() => json!("hello")),
@@ -183,12 +183,12 @@ fn test_contains_duplicate_currency() {
         TestCase {
             name: "symbol mismatch",
             payload: vec![
-                Some(NullableCurrency {
+                Some(UncheckedCurrency {
                     symbol: "ERX".to_string(),
                     decimals: 8,
                     metadata: Default::default(),
                 }),
-                Some(NullableCurrency {
+                Some(UncheckedCurrency {
                     symbol: "BTC".to_string(),
                     decimals: 8,
                     metadata: Default::default(),
@@ -199,12 +199,12 @@ fn test_contains_duplicate_currency() {
         TestCase {
             name: "decimal mismatch",
             payload: vec![
-                Some(NullableCurrency {
+                Some(UncheckedCurrency {
                     symbol: "BTC".to_string(),
                     decimals: 8,
                     metadata: Default::default(),
                 }),
-                Some(NullableCurrency {
+                Some(UncheckedCurrency {
                     symbol: "BTC".to_string(),
                     decimals: 6,
                     metadata: Default::default(),
@@ -215,12 +215,12 @@ fn test_contains_duplicate_currency() {
         TestCase {
             name: "metadata mismatch",
             payload: vec![
-                Some(NullableCurrency {
+                Some(UncheckedCurrency {
                     symbol: "BTC".to_string(),
                     decimals: 8,
                     metadata: indexmap!("blah".to_string() => json!("hello")),
                 }),
-                Some(NullableCurrency {
+                Some(UncheckedCurrency {
                     symbol: "BTC".to_string(),
                     decimals: 8,
                     metadata: indexmap!("blah".to_string() => json!("bye")),
@@ -237,9 +237,9 @@ fn test_contains_duplicate_currency() {
 
 #[derive(Default)]
 struct AccountBalanceTest {
-    request_block: Option<NullablePartialBlockIdentifier>,
-    response_block: NullableBlockIdentifier,
-    balances: Vec<Option<NullableAmount>>,
+    request_block: Option<UncheckedPartialBlockIdentifier>,
+    response_block: UncheckedBlockIdentifier,
+    balances: Vec<Option<UncheckedAmount>>,
     _metadata: IndexMap<String, Value>,
 }
 
@@ -247,7 +247,7 @@ impl AccountBalanceTest {
     fn run(self) -> AssertResult<()> {
         account_balance_response(
             self.request_block.as_ref(),
-            &NullableAccountBalanceResponse {
+            &UncheckedAccountBalanceResponse {
                 block_identifier: Some(self.response_block.clone()),
                 balances: self.balances.clone(),
                 metadata: Default::default(),
@@ -258,11 +258,11 @@ impl AccountBalanceTest {
 
 #[test]
 fn test_account_balance() {
-    let valid_block = NullableBlockIdentifier {
+    let valid_block = UncheckedBlockIdentifier {
         index: 1000,
         hash: "jsakdl".to_string(),
     };
-    let invalid_block = NullableBlockIdentifier {
+    let invalid_block = UncheckedBlockIdentifier {
         index: 1,
         hash: String::new(),
     };
@@ -270,9 +270,9 @@ fn test_account_balance() {
     let invalid_index = 1001;
     let invalid_hash = "ajsdk";
 
-    let valid_amt = Some(NullableAmount {
+    let valid_amt = Some(UncheckedAmount {
         value: "100".to_string(),
-        currency: Some(NullableCurrency {
+        currency: Some(UncheckedCurrency {
             symbol: "BTC".to_string(),
             decimals: 8,
             metadata: Default::default(),
@@ -320,7 +320,7 @@ fn test_account_balance() {
         TestCase {
             name: "valid historical request index",
             payload: AccountBalanceTest {
-                request_block: Some(NullablePartialBlockIdentifier {
+                request_block: Some(UncheckedPartialBlockIdentifier {
                     index: Some(valid_block.index),
                     hash: None,
                 }),
@@ -333,7 +333,7 @@ fn test_account_balance() {
         TestCase {
             name: "valid historical request hash",
             payload: AccountBalanceTest {
-                request_block: Some(NullablePartialBlockIdentifier {
+                request_block: Some(UncheckedPartialBlockIdentifier {
                     index: None,
                     hash: Some(valid_block.hash.clone()),
                 }),
@@ -346,7 +346,7 @@ fn test_account_balance() {
         TestCase {
             name: "invalid historical request index",
             payload: AccountBalanceTest {
-                request_block: Some(NullablePartialBlockIdentifier {
+                request_block: Some(UncheckedPartialBlockIdentifier {
                     index: Some(invalid_index),
                     hash: Some(valid_block.hash.clone()),
                 }),
@@ -363,7 +363,7 @@ fn test_account_balance() {
         TestCase {
             name: "invalid historical request hash",
             payload: AccountBalanceTest {
-                request_block: Some(NullablePartialBlockIdentifier {
+                request_block: Some(UncheckedPartialBlockIdentifier {
                     index: Some(valid_block.index),
                     hash: Some(invalid_hash.to_string()),
                 }),

--- a/crates/mentat-asserter/src/account_test.rs
+++ b/crates/mentat-asserter/src/account_test.rs
@@ -237,8 +237,8 @@ fn test_contains_duplicate_currency() {
 
 #[derive(Default)]
 struct AccountBalanceTest {
-    request_block: Option<PartialBlockIdentifier>,
-    response_block: BlockIdentifier,
+    request_block: Option<NullablePartialBlockIdentifier>,
+    response_block: NullableBlockIdentifier,
     balances: Vec<Option<NullableAmount>>,
     _metadata: IndexMap<String, Value>,
 }
@@ -258,11 +258,11 @@ impl AccountBalanceTest {
 
 #[test]
 fn test_account_balance() {
-    let valid_block = BlockIdentifier {
+    let valid_block = NullableBlockIdentifier {
         index: 1000,
         hash: "jsakdl".to_string(),
     };
-    let invalid_block = BlockIdentifier {
+    let invalid_block = NullableBlockIdentifier {
         index: 1,
         hash: String::new(),
     };
@@ -320,7 +320,7 @@ fn test_account_balance() {
         TestCase {
             name: "valid historical request index",
             payload: AccountBalanceTest {
-                request_block: Some(PartialBlockIdentifier {
+                request_block: Some(NullablePartialBlockIdentifier {
                     index: Some(valid_block.index),
                     hash: None,
                 }),
@@ -333,7 +333,7 @@ fn test_account_balance() {
         TestCase {
             name: "valid historical request hash",
             payload: AccountBalanceTest {
-                request_block: Some(PartialBlockIdentifier {
+                request_block: Some(NullablePartialBlockIdentifier {
                     index: None,
                     hash: Some(valid_block.hash.clone()),
                 }),
@@ -346,7 +346,7 @@ fn test_account_balance() {
         TestCase {
             name: "invalid historical request index",
             payload: AccountBalanceTest {
-                request_block: Some(PartialBlockIdentifier {
+                request_block: Some(NullablePartialBlockIdentifier {
                     index: Some(invalid_index),
                     hash: Some(valid_block.hash.clone()),
                 }),
@@ -363,7 +363,7 @@ fn test_account_balance() {
         TestCase {
             name: "invalid historical request hash",
             payload: AccountBalanceTest {
-                request_block: Some(PartialBlockIdentifier {
+                request_block: Some(NullablePartialBlockIdentifier {
                     index: Some(valid_block.index),
                     hash: Some(invalid_hash.to_string()),
                 }),

--- a/crates/mentat-asserter/src/asserter_tools.rs
+++ b/crates/mentat-asserter/src/asserter_tools.rs
@@ -66,8 +66,8 @@ impl Validations {
 pub(crate) struct ResponseAsserter {
     pub(crate) network: NetworkIdentifier,
     pub(crate) operation_status_map: IndexMap<String, bool>,
-    pub(crate) error_type_map: IndexMap<isize, NullableMentatError>,
-    pub(crate) genesis_block: NullableBlockIdentifier,
+    pub(crate) error_type_map: IndexMap<isize, UncheckedMentatError>,
+    pub(crate) genesis_block: UncheckedBlockIdentifier,
     pub(crate) timestamp_start_index: usize,
 }
 
@@ -136,10 +136,10 @@ impl Asserter {
     /// NetworkOptionsResponse.
     pub fn new_client_with_options(
         network: Option<NetworkIdentifier>,
-        genesis_block: Option<NullableBlockIdentifier>,
+        genesis_block: Option<UncheckedBlockIdentifier>,
         operation_types_: Vec<String>,
         operation_stats: Vec<Option<OperationStatus>>,
-        errors: Vec<Option<NullableMentatError>>,
+        errors: Vec<Option<UncheckedMentatError>>,
         timestamp_start_index: Option<isize>,
         validations: Validations,
     ) -> AssertResult<Self> {
@@ -198,8 +198,8 @@ impl Asserter {
     /// NetworkOptionsResponse.
     pub(crate) fn new_client_with_responses(
         network: Option<NetworkIdentifier>,
-        status: Option<NullableNetworkStatusResponse>,
-        options: Option<NullableNetworkOptionsResponse>,
+        status: Option<UncheckedNetworkStatusResponse>,
+        options: Option<UncheckedNetworkOptionsResponse>,
         validation_file_path: Option<&PathBuf>,
     ) -> AssertResult<Self> {
         network_identifier(network.as_ref())?;
@@ -277,10 +277,10 @@ impl Asserter {
 #[allow(clippy::missing_docs_in_private_items)]
 pub(crate) struct Configuration {
     pub(crate) network_identifier: Option<NetworkIdentifier>,
-    pub(crate) genesis_block_identifier: Option<NullableBlockIdentifier>,
+    pub(crate) genesis_block_identifier: Option<UncheckedBlockIdentifier>,
     pub(crate) allowed_operation_types: Vec<String>,
     pub(crate) allowed_operation_statuses: Vec<Option<OperationStatus>>,
-    pub(crate) allowed_errors: Vec<Option<NullableMentatError>>,
+    pub(crate) allowed_errors: Vec<Option<UncheckedMentatError>>,
     pub(crate) allowed_timestamp_start_index: Option<isize>,
 }
 

--- a/crates/mentat-asserter/src/asserter_tools_test.rs
+++ b/crates/mentat-asserter/src/asserter_tools_test.rs
@@ -24,11 +24,11 @@ fn test_new() {
         sub_network_identifier: Default::default(),
     });
     let valid_network_status = Some(NullableNetworkStatusResponse {
-        genesis_block_identifier: Some(BlockIdentifier {
+        genesis_block_identifier: Some(NullableBlockIdentifier {
             index: 0,
             hash: "block 0".into(),
         }),
-        current_block_identifier: Some(BlockIdentifier {
+        current_block_identifier: Some(NullableBlockIdentifier {
             index: 100,
             hash: "block 100".into(),
         }),
@@ -40,11 +40,11 @@ fn test_new() {
         ..Default::default()
     });
     let valid_network_status_sync_status = Some(NullableNetworkStatusResponse {
-        genesis_block_identifier: Some(BlockIdentifier {
+        genesis_block_identifier: Some(NullableBlockIdentifier {
             index: 0,
             hash: "block 0".into(),
         }),
-        current_block_identifier: Some(BlockIdentifier {
+        current_block_identifier: Some(NullableBlockIdentifier {
             index: 100,
             hash: "block 100".into(),
         }),
@@ -53,7 +53,7 @@ fn test_new() {
             peer_id: "peer 1".into(),
             metadata: Default::default(),
         })],
-        sync_status: Some(SyncStatus {
+        sync_status: Some(NullableSyncStatus {
             current_index: Some(100),
             stage: Some("pre-sync".into()),
             ..Default::default()
@@ -61,7 +61,7 @@ fn test_new() {
         oldest_block_identifier: None,
     });
     let invalid_network_status = Some(NullableNetworkStatusResponse {
-        current_block_identifier: Some(BlockIdentifier {
+        current_block_identifier: Some(NullableBlockIdentifier {
             index: 100,
             hash: "block 100".into(),
         }),
@@ -73,11 +73,11 @@ fn test_new() {
         ..Default::default()
     });
     let invalid_network_status_sync_status = Some(NullableNetworkStatusResponse {
-        genesis_block_identifier: Some(BlockIdentifier {
+        genesis_block_identifier: Some(NullableBlockIdentifier {
             index: 0,
             hash: "block 0".into(),
         }),
-        current_block_identifier: Some(BlockIdentifier {
+        current_block_identifier: Some(NullableBlockIdentifier {
             index: 100,
             hash: "block 100".into(),
         }),
@@ -86,7 +86,7 @@ fn test_new() {
             peer_id: "peer 1".into(),
             metadata: Default::default(),
         })],
-        sync_status: Some(SyncStatus {
+        sync_status: Some(NullableSyncStatus {
             current_index: Some(-100),
             stage: Some("pre-sync".into()),
             ..Default::default()
@@ -105,7 +105,7 @@ fn test_new() {
                 successful: true,
             })],
             operation_types: vec!["Transfer".to_string()],
-            errors: vec![Some(MentatError {
+            errors: vec![Some(NullableMentatError {
                 status_code: 0,
                 code: 1,
                 message: "error".into(),
@@ -128,7 +128,7 @@ fn test_new() {
                 successful: true,
             })],
             operation_types: vec!["Transfer".to_string()],
-            errors: vec![Some(MentatError {
+            errors: vec![Some(NullableMentatError {
                 status_code: 0,
                 code: 1,
                 message: "error".into(),
@@ -148,7 +148,7 @@ fn test_new() {
         }),
         allow: Some(NullableAllow {
             operation_types: vec!["Transfer".to_string()],
-            errors: vec![Some(MentatError {
+            errors: vec![Some(NullableMentatError {
                 status_code: 0,
                 code: 1,
                 message: "error".into(),
@@ -176,7 +176,7 @@ fn test_new() {
                 }),
             ],
             operation_types: vec!["Transfer".to_string()],
-            errors: vec![Some(MentatError {
+            errors: vec![Some(NullableMentatError {
                 status_code: 0,
                 code: 1,
                 message: "error".into(),
@@ -198,7 +198,7 @@ fn test_new() {
                 successful: true,
             })],
             operation_types: vec!["Transfer".to_string(), "Transfer".to_string()],
-            errors: vec![Some(MentatError {
+            errors: vec![Some(NullableMentatError {
                 status_code: 0,
                 code: 1,
                 message: "error".into(),
@@ -220,7 +220,7 @@ fn test_new() {
                 successful: true,
             })],
             operation_types: vec!["Transfer".to_string()],
-            errors: vec![Some(MentatError {
+            errors: vec![Some(NullableMentatError {
                 status_code: 0,
                 code: 1,
                 message: "error".into(),

--- a/crates/mentat-asserter/src/asserter_tools_test.rs
+++ b/crates/mentat-asserter/src/asserter_tools_test.rs
@@ -10,8 +10,8 @@ use super::*;
 #[derive(Default)]
 struct TestNewExtras {
     network: Option<NetworkIdentifier>,
-    network_status: Option<NullableNetworkStatusResponse>,
-    network_options: Option<NullableNetworkOptionsResponse>,
+    network_status: Option<UncheckedNetworkStatusResponse>,
+    network_options: Option<UncheckedNetworkOptionsResponse>,
     validation_file_path: Option<PathBuf>,
     skip_load_test: bool,
 }
@@ -23,12 +23,12 @@ fn test_new() {
         network: "WORLD".into(),
         sub_network_identifier: Default::default(),
     });
-    let valid_network_status = Some(NullableNetworkStatusResponse {
-        genesis_block_identifier: Some(NullableBlockIdentifier {
+    let valid_network_status = Some(UncheckedNetworkStatusResponse {
+        genesis_block_identifier: Some(UncheckedBlockIdentifier {
             index: 0,
             hash: "block 0".into(),
         }),
-        current_block_identifier: Some(NullableBlockIdentifier {
+        current_block_identifier: Some(UncheckedBlockIdentifier {
             index: 100,
             hash: "block 100".into(),
         }),
@@ -39,12 +39,12 @@ fn test_new() {
         })],
         ..Default::default()
     });
-    let valid_network_status_sync_status = Some(NullableNetworkStatusResponse {
-        genesis_block_identifier: Some(NullableBlockIdentifier {
+    let valid_network_status_sync_status = Some(UncheckedNetworkStatusResponse {
+        genesis_block_identifier: Some(UncheckedBlockIdentifier {
             index: 0,
             hash: "block 0".into(),
         }),
-        current_block_identifier: Some(NullableBlockIdentifier {
+        current_block_identifier: Some(UncheckedBlockIdentifier {
             index: 100,
             hash: "block 100".into(),
         }),
@@ -53,15 +53,15 @@ fn test_new() {
             peer_id: "peer 1".into(),
             metadata: Default::default(),
         })],
-        sync_status: Some(NullableSyncStatus {
+        sync_status: Some(UncheckedSyncStatus {
             current_index: Some(100),
             stage: Some("pre-sync".into()),
             ..Default::default()
         }),
         oldest_block_identifier: None,
     });
-    let invalid_network_status = Some(NullableNetworkStatusResponse {
-        current_block_identifier: Some(NullableBlockIdentifier {
+    let invalid_network_status = Some(UncheckedNetworkStatusResponse {
+        current_block_identifier: Some(UncheckedBlockIdentifier {
             index: 100,
             hash: "block 100".into(),
         }),
@@ -72,12 +72,12 @@ fn test_new() {
         })],
         ..Default::default()
     });
-    let invalid_network_status_sync_status = Some(NullableNetworkStatusResponse {
-        genesis_block_identifier: Some(NullableBlockIdentifier {
+    let invalid_network_status_sync_status = Some(UncheckedNetworkStatusResponse {
+        genesis_block_identifier: Some(UncheckedBlockIdentifier {
             index: 0,
             hash: "block 0".into(),
         }),
-        current_block_identifier: Some(NullableBlockIdentifier {
+        current_block_identifier: Some(UncheckedBlockIdentifier {
             index: 100,
             hash: "block 100".into(),
         }),
@@ -86,26 +86,26 @@ fn test_new() {
             peer_id: "peer 1".into(),
             metadata: Default::default(),
         })],
-        sync_status: Some(NullableSyncStatus {
+        sync_status: Some(UncheckedSyncStatus {
             current_index: Some(-100),
             stage: Some("pre-sync".into()),
             ..Default::default()
         }),
         oldest_block_identifier: None,
     });
-    let valid_network_options = Some(NullableNetworkOptionsResponse {
+    let valid_network_options = Some(UncheckedNetworkOptionsResponse {
         version: Some(Version {
             rosetta_version: "1.4.0".into(),
             node_version: "1.0".into(),
             ..Default::default()
         }),
-        allow: Some(NullableAllow {
+        allow: Some(UncheckedAllow {
             operation_statuses: vec![Some(OperationStatus {
                 status: "Success".into(),
                 successful: true,
             })],
             operation_types: vec!["Transfer".to_string()],
-            errors: vec![Some(NullableMentatError {
+            errors: vec![Some(UncheckedMentatError {
                 status_code: 0,
                 code: 1,
                 message: "error".into(),
@@ -116,19 +116,19 @@ fn test_new() {
             ..Default::default()
         }),
     });
-    let valid_network_options_with_start_index = Some(NullableNetworkOptionsResponse {
+    let valid_network_options_with_start_index = Some(UncheckedNetworkOptionsResponse {
         version: Some(Version {
             rosetta_version: "1.4.0".into(),
             node_version: "1.0".into(),
             ..Default::default()
         }),
-        allow: Some(NullableAllow {
+        allow: Some(UncheckedAllow {
             operation_statuses: vec![Some(OperationStatus {
                 status: "Success".into(),
                 successful: true,
             })],
             operation_types: vec!["Transfer".to_string()],
-            errors: vec![Some(NullableMentatError {
+            errors: vec![Some(UncheckedMentatError {
                 status_code: 0,
                 code: 1,
                 message: "error".into(),
@@ -140,15 +140,15 @@ fn test_new() {
             ..Default::default()
         }),
     });
-    let invalid_network_options = Some(NullableNetworkOptionsResponse {
+    let invalid_network_options = Some(UncheckedNetworkOptionsResponse {
         version: Some(Version {
             rosetta_version: "1.4.0".into(),
             node_version: "1.0".into(),
             ..Default::default()
         }),
-        allow: Some(NullableAllow {
+        allow: Some(UncheckedAllow {
             operation_types: vec!["Transfer".to_string()],
-            errors: vec![Some(NullableMentatError {
+            errors: vec![Some(UncheckedMentatError {
                 status_code: 0,
                 code: 1,
                 message: "error".into(),
@@ -158,13 +158,13 @@ fn test_new() {
             ..Default::default()
         }),
     });
-    let duplicate_statuses = Some(NullableNetworkOptionsResponse {
+    let duplicate_statuses = Some(UncheckedNetworkOptionsResponse {
         version: Some(Version {
             rosetta_version: "1.4.0".into(),
             node_version: "1.0".into(),
             ..Default::default()
         }),
-        allow: Some(NullableAllow {
+        allow: Some(UncheckedAllow {
             operation_statuses: vec![
                 Some(OperationStatus {
                     status: "Success".into(),
@@ -176,7 +176,7 @@ fn test_new() {
                 }),
             ],
             operation_types: vec!["Transfer".to_string()],
-            errors: vec![Some(NullableMentatError {
+            errors: vec![Some(UncheckedMentatError {
                 status_code: 0,
                 code: 1,
                 message: "error".into(),
@@ -186,19 +186,19 @@ fn test_new() {
             ..Default::default()
         }),
     });
-    let duplicate_types = Some(NullableNetworkOptionsResponse {
+    let duplicate_types = Some(UncheckedNetworkOptionsResponse {
         version: Some(Version {
             rosetta_version: "1.4.0".into(),
             node_version: "1.0".into(),
             ..Default::default()
         }),
-        allow: Some(NullableAllow {
+        allow: Some(UncheckedAllow {
             operation_statuses: vec![Some(OperationStatus {
                 status: "Success".into(),
                 successful: true,
             })],
             operation_types: vec!["Transfer".to_string(), "Transfer".to_string()],
-            errors: vec![Some(NullableMentatError {
+            errors: vec![Some(UncheckedMentatError {
                 status_code: 0,
                 code: 1,
                 message: "error".into(),
@@ -208,19 +208,19 @@ fn test_new() {
             ..Default::default()
         }),
     });
-    let negative_start_index = Some(NullableNetworkOptionsResponse {
+    let negative_start_index = Some(UncheckedNetworkOptionsResponse {
         version: Some(Version {
             rosetta_version: "1.4.0".into(),
             node_version: "1.0".into(),
             ..Default::default()
         }),
-        allow: Some(NullableAllow {
+        allow: Some(UncheckedAllow {
             operation_statuses: vec![Some(OperationStatus {
                 status: "Success".into(),
                 successful: true,
             })],
             operation_types: vec!["Transfer".to_string()],
-            errors: vec![Some(NullableMentatError {
+            errors: vec![Some(UncheckedMentatError {
                 status_code: 0,
                 code: 1,
                 message: "error".into(),

--- a/crates/mentat-asserter/src/block.rs
+++ b/crates/mentat-asserter/src/block.rs
@@ -7,7 +7,7 @@ use num_bigint_dig::{BigInt, Sign};
 use super::*;
 
 /// `currency` ensures a [`Currency`] is valid.
-pub fn currency(currency: Option<&NullableCurrency>) -> AssertResult<()> {
+pub fn currency(currency: Option<&UncheckedCurrency>) -> AssertResult<()> {
     let currency = currency.ok_or(BlockError::AmountCurrencyIsNil)?;
     if currency.symbol.is_empty() {
         Err(BlockError::AmountCurrencySymbolEmpty)?
@@ -20,7 +20,7 @@ pub fn currency(currency: Option<&NullableCurrency>) -> AssertResult<()> {
 
 /// `amount` ensures a [`Amount`] has an
 /// integer value, specified precision, and symbol.
-pub fn amount(amount: Option<&NullableAmount>) -> AssertResult<()> {
+pub fn amount(amount: Option<&UncheckedAmount>) -> AssertResult<()> {
     let amount = amount.ok_or(BlockError::AmountValueMissing)?;
 
     if amount.value.is_empty() {
@@ -33,10 +33,10 @@ pub fn amount(amount: Option<&NullableAmount>) -> AssertResult<()> {
 }
 
 /// `operation_identifier` returns an error if index of the
-/// [`NullableOperationIdentifier`] is out-of-order or if the NetworkIndex is
+/// [`UncheckedOperationIdentifier`] is out-of-order or if the NetworkIndex is
 /// invalid.
 pub fn operation_identifier(
-    ident: Option<&NullableOperationIdentifier>,
+    ident: Option<&UncheckedOperationIdentifier>,
     index: isize,
 ) -> AssertResult<()> {
     let ident = ident.ok_or(BlockError::OperationIdentifierIndexIsNil)?;
@@ -130,7 +130,7 @@ impl Asserter {
     /// type, status, and amount.
     pub fn operation(
         &self,
-        operation: Option<&NullableOperation>,
+        operation: Option<&UncheckedOperation>,
         index: isize,
         construction: bool,
     ) -> AssertResult<()> {
@@ -174,7 +174,7 @@ impl Asserter {
     /// in a [`TypesOperation`] is invalid.
     pub fn operations(
         &self,
-        operations: &[Option<NullableOperation>],
+        operations: &[Option<UncheckedOperation>],
         construction: bool,
     ) -> AssertResult<()> {
         if operations.is_empty() && construction {
@@ -300,7 +300,7 @@ impl Asserter {
     /// `transaction` returns an error if the [`TransactionIdentifier`]
     /// is invalid, if any [`TypesOperation`] within the [`Transaction`]
     /// is invalid, or if any operation index is reused within a transaction.
-    pub fn transaction(&self, transaction: Option<&NullableTransaction>) -> AssertResult<()> {
+    pub fn transaction(&self, transaction: Option<&UncheckedTransaction>) -> AssertResult<()> {
         self.response
             .as_ref()
             .ok_or(AsserterError::NotInitialized)?;
@@ -336,7 +336,7 @@ impl Asserter {
     /// defined by the enum.
     pub fn related_transactions(
         &self,
-        related_transactions: &[Option<NullableRelatedTransaction>],
+        related_transactions: &[Option<UncheckedRelatedTransaction>],
     ) -> AssertResult<()> {
         if let Some(dup) = duplicate_related_transaction(related_transactions) {
             Err(format!(
@@ -369,7 +369,7 @@ impl Asserter {
 
     /// `direction` returns an error if the value passed is not
     /// [Direction::Forward] or [Direction::Backward]
-    pub fn direction(&self, direction: &NullableDirection) -> AssertResult<()> {
+    pub fn direction(&self, direction: &UncheckedDirection) -> AssertResult<()> {
         if !direction.valid() {
             Err(BlockError::InvalidDirection)?
         } else {
@@ -378,7 +378,7 @@ impl Asserter {
     }
 
     /// `block` runs a basic set of assertions for each returned [`Block`].
-    pub fn block(&self, block: Option<&NullableBlock>) -> AssertResult<()> {
+    pub fn block(&self, block: Option<&UncheckedBlock>) -> AssertResult<()> {
         let asserter = self
             .response
             .as_ref()
@@ -413,9 +413,9 @@ impl Asserter {
     }
 }
 
-/// `block_identifier` ensures a [`NullableBlockIdentifier`]
+/// `block_identifier` ensures a [`UncheckedBlockIdentifier`]
 /// is well-formatted.
-pub fn block_identifier(block: Option<&NullableBlockIdentifier>) -> AssertResult<()> {
+pub fn block_identifier(block: Option<&UncheckedBlockIdentifier>) -> AssertResult<()> {
     let block = block.ok_or(BlockError::BlockIdentifierIsNil)?;
     if block.hash.is_empty() {
         Err(BlockError::BlockIdentifierHashMissing)?
@@ -426,10 +426,10 @@ pub fn block_identifier(block: Option<&NullableBlockIdentifier>) -> AssertResult
     }
 }
 
-/// `partial_block_identifier` ensures a [`NullablePartialBlockIdentifier`]
+/// `partial_block_identifier` ensures a [`UncheckedPartialBlockIdentifier`]
 /// is well-formatted.
 pub fn partial_block_identifier(
-    block_identifier: Option<&NullablePartialBlockIdentifier>,
+    block_identifier: Option<&UncheckedPartialBlockIdentifier>,
 ) -> AssertResult<()> {
     let block_identifier = block_identifier.ok_or(BlockError::PartialBlockIdentifierIsNil)?;
     if matches!(&block_identifier.hash, Some(hash) if !hash.is_empty())
@@ -444,8 +444,8 @@ pub fn partial_block_identifier(
 /// `duplicate_related_transaction` returns nil if no duplicates are found in
 /// the array and returns the first duplicated item found otherwise.
 pub fn duplicate_related_transaction(
-    items: &[Option<NullableRelatedTransaction>],
-) -> Option<&NullableRelatedTransaction> {
+    items: &[Option<UncheckedRelatedTransaction>],
+) -> Option<&UncheckedRelatedTransaction> {
     let mut seen = IndexSet::new();
 
     for item in items {

--- a/crates/mentat-asserter/src/block.rs
+++ b/crates/mentat-asserter/src/block.rs
@@ -33,9 +33,12 @@ pub fn amount(amount: Option<&NullableAmount>) -> AssertResult<()> {
 }
 
 /// `operation_identifier` returns an error if index of the
-/// [`OperationIdentifier`] is out-of-order or if the NetworkIndex is
+/// [`NullableOperationIdentifier`] is out-of-order or if the NetworkIndex is
 /// invalid.
-pub fn operation_identifier(ident: Option<&OperationIdentifier>, index: i64) -> AssertResult<()> {
+pub fn operation_identifier(
+    ident: Option<&NullableOperationIdentifier>,
+    index: isize,
+) -> AssertResult<()> {
     let ident = ident.ok_or(BlockError::OperationIdentifierIndexIsNil)?;
 
     if ident.index != index {
@@ -128,7 +131,7 @@ impl Asserter {
     pub fn operation(
         &self,
         operation: Option<&NullableOperation>,
-        index: i64,
+        index: isize,
         construction: bool,
     ) -> AssertResult<()> {
         if self.response.is_none() && self.request.is_none() {
@@ -185,7 +188,7 @@ impl Asserter {
         let mut related_ops_exist = false;
 
         for (index, op) in operations.iter().enumerate() {
-            self.operation(op.as_ref(), index as i64, construction)?;
+            self.operation(op.as_ref(), index as isize, construction)?;
             let op = op.as_ref().unwrap();
             if self.validations.enabled {
                 if op.type_ == self.validations.payment.name {
@@ -266,9 +269,9 @@ impl Asserter {
     pub fn validate_payment_and_fee(
         &self,
         payment_total: BigInt,
-        payment_count: i64,
+        payment_count: isize,
         fee_total: BigInt,
-        fee_count: i64,
+        fee_count: isize,
     ) -> AssertResult<()> {
         let zero = BigInt::from(0u8);
         if self.validations.payment.operation.count != -1
@@ -399,7 +402,7 @@ impl Asserter {
 
         // Only check for timestamp validity if timestamp start index is <=
         // the current block index.
-        if asserter.timestamp_start_index <= block_identifier.index {
+        if asserter.timestamp_start_index as isize <= block_identifier.index {
             timestamp(block.timestamp)?;
         }
 
@@ -410,9 +413,9 @@ impl Asserter {
     }
 }
 
-/// `block_identifier` ensures a [`BlockIdentifier`]
+/// `block_identifier` ensures a [`NullableBlockIdentifier`]
 /// is well-formatted.
-pub fn block_identifier(block: Option<&BlockIdentifier>) -> AssertResult<()> {
+pub fn block_identifier(block: Option<&NullableBlockIdentifier>) -> AssertResult<()> {
     let block = block.ok_or(BlockError::BlockIdentifierIsNil)?;
     if block.hash.is_empty() {
         Err(BlockError::BlockIdentifierHashMissing)?
@@ -423,10 +426,10 @@ pub fn block_identifier(block: Option<&BlockIdentifier>) -> AssertResult<()> {
     }
 }
 
-/// `partial_block_identifier` ensures a [`PartialBlockIdentifier`]
+/// `partial_block_identifier` ensures a [`NullablePartialBlockIdentifier`]
 /// is well-formatted.
 pub fn partial_block_identifier(
-    block_identifier: Option<&PartialBlockIdentifier>,
+    block_identifier: Option<&NullablePartialBlockIdentifier>,
 ) -> AssertResult<()> {
     let block_identifier = block_identifier.ok_or(BlockError::PartialBlockIdentifierIsNil)?;
     if matches!(&block_identifier.hash, Some(hash) if !hash.is_empty())
@@ -470,13 +473,13 @@ pub fn transaction_identifier(ident: Option<&TransactionIdentifier>) -> AssertRe
 }
 
 /// The min unix epoch
-pub static MIN_UNIX_EPOCH: i64 = 946713600000;
+pub static MIN_UNIX_EPOCH: isize = 946713600000;
 /// The max unix epoch
-pub static MAX_UNIX_EPOCH: i64 = 2209017600000;
+pub static MAX_UNIX_EPOCH: isize = 2209017600000;
 
 /// `timestamp` returns an error if the timestamp
 /// on a block is less than or equal to 0.
-pub fn timestamp(timestamp: i64) -> Result<(), String> {
+pub fn timestamp(timestamp: isize) -> Result<(), String> {
     if timestamp < MIN_UNIX_EPOCH {
         Err(format!("{}: {timestamp}", BlockError::TimestampBeforeMin))
     } else if timestamp > MAX_UNIX_EPOCH {

--- a/crates/mentat-asserter/src/block_test.rs
+++ b/crates/mentat-asserter/src/block_test.rs
@@ -7,7 +7,7 @@ fn test_block_identifier() {
     let tests = vec![
         TestCase {
             name: "valid identifier",
-            payload: Some(NullableBlockIdentifier {
+            payload: Some(UncheckedBlockIdentifier {
                 index: 1,
                 hash: "block 1".into(),
             }),
@@ -20,7 +20,7 @@ fn test_block_identifier() {
         },
         TestCase {
             name: "invalid index",
-            payload: Some(NullableBlockIdentifier {
+            payload: Some(UncheckedBlockIdentifier {
                 index: -1,
                 hash: "block 1".into(),
             }),
@@ -28,7 +28,7 @@ fn test_block_identifier() {
         },
         TestCase {
             name: "invalid hash",
-            payload: Some(NullableBlockIdentifier {
+            payload: Some(UncheckedBlockIdentifier {
                 index: 1,
                 hash: String::new(),
             }),
@@ -44,9 +44,9 @@ fn test_amount() {
     let tests = vec![
         TestCase {
             name: "valid amount",
-            payload: Some(NullableAmount {
+            payload: Some(UncheckedAmount {
                 value: "100000".into(),
-                currency: Some(NullableCurrency {
+                currency: Some(UncheckedCurrency {
                     symbol: "BTC".into(),
                     decimals: 1,
                     metadata: Default::default(),
@@ -57,9 +57,9 @@ fn test_amount() {
         },
         TestCase {
             name: "valid amount no decimals",
-            payload: Some(NullableAmount {
+            payload: Some(UncheckedAmount {
                 value: "100000".into(),
-                currency: Some(NullableCurrency {
+                currency: Some(UncheckedCurrency {
                     symbol: "BTC".into(),
                     decimals: Default::default(),
                     metadata: Default::default(),
@@ -70,9 +70,9 @@ fn test_amount() {
         },
         TestCase {
             name: "valid negative amount",
-            payload: Some(NullableAmount {
+            payload: Some(UncheckedAmount {
                 value: "-100000".into(),
-                currency: Some(NullableCurrency {
+                currency: Some(UncheckedCurrency {
                     symbol: "BTC".into(),
                     decimals: 1,
                     metadata: Default::default(),
@@ -88,7 +88,7 @@ fn test_amount() {
         },
         TestCase {
             name: "nil currency",
-            payload: Some(NullableAmount {
+            payload: Some(UncheckedAmount {
                 value: "-100000".into(),
                 currency: None,
                 metadata: Default::default(),
@@ -97,9 +97,9 @@ fn test_amount() {
         },
         TestCase {
             name: "invalid non number",
-            payload: Some(NullableAmount {
+            payload: Some(UncheckedAmount {
                 value: "blah".into(),
-                currency: Some(NullableCurrency {
+                currency: Some(UncheckedCurrency {
                     symbol: "BTC".into(),
                     decimals: 1,
                     metadata: Default::default(),
@@ -113,9 +113,9 @@ fn test_amount() {
         },
         TestCase {
             name: "invalid integer format",
-            payload: Some(NullableAmount {
+            payload: Some(UncheckedAmount {
                 value: "1.0".into(),
-                currency: Some(NullableCurrency {
+                currency: Some(UncheckedCurrency {
                     symbol: "BTC".into(),
                     decimals: 1,
                     metadata: Default::default(),
@@ -129,9 +129,9 @@ fn test_amount() {
         },
         TestCase {
             name: "invalid non-integer",
-            payload: Some(NullableAmount {
+            payload: Some(UncheckedAmount {
                 value: "1.1".into(),
-                currency: Some(NullableCurrency {
+                currency: Some(UncheckedCurrency {
                     symbol: "BTC".into(),
                     decimals: 1,
                     metadata: Default::default(),
@@ -145,9 +145,9 @@ fn test_amount() {
         },
         TestCase {
             name: "invalid symbol",
-            payload: Some(NullableAmount {
+            payload: Some(UncheckedAmount {
                 value: "11".into(),
-                currency: Some(NullableCurrency {
+                currency: Some(UncheckedCurrency {
                     symbol: String::new(),
                     decimals: 1,
                     metadata: Default::default(),
@@ -158,9 +158,9 @@ fn test_amount() {
         },
         TestCase {
             name: "invalid decimals",
-            payload: Some(NullableAmount {
+            payload: Some(UncheckedAmount {
                 value: "111".into(),
-                currency: Some(NullableCurrency {
+                currency: Some(UncheckedCurrency {
                     symbol: "BTC".into(),
                     decimals: -1,
                     metadata: Default::default(),
@@ -176,7 +176,7 @@ fn test_amount() {
 
 #[derive(Default)]
 struct OperationIdentTest {
-    ident: Option<NullableOperationIdentifier>,
+    ident: Option<UncheckedOperationIdentifier>,
     index: isize,
 }
 
@@ -195,7 +195,7 @@ fn test_operation_identifier() {
         TestCase {
             name: "valid identifier",
             payload: Some(OperationIdentTest {
-                ident: Some(NullableOperationIdentifier {
+                ident: Some(UncheckedOperationIdentifier {
                     index: 0,
                     network_index: None,
                 }),
@@ -214,7 +214,7 @@ fn test_operation_identifier() {
         TestCase {
             name: "out-of-order index",
             payload: Some(OperationIdentTest {
-                ident: Some(NullableOperationIdentifier {
+                ident: Some(UncheckedOperationIdentifier {
                     index: 0,
                     network_index: None,
                 }),
@@ -225,7 +225,7 @@ fn test_operation_identifier() {
         TestCase {
             name: "valid identifier with network index",
             payload: Some(OperationIdentTest {
-                ident: Some(NullableOperationIdentifier {
+                ident: Some(UncheckedOperationIdentifier {
                     index: 0,
                     network_index: Some(valid_network_index),
                 }),
@@ -236,7 +236,7 @@ fn test_operation_identifier() {
         TestCase {
             name: "invalid identifier with network index",
             payload: Some(OperationIdentTest {
-                ident: Some(NullableOperationIdentifier {
+                ident: Some(UncheckedOperationIdentifier {
                     index: 0,
                     network_index: Some(invalid_network_index),
                 }),
@@ -301,42 +301,42 @@ fn test_account_identifier() {
 
 #[derive(Default)]
 struct OperationValidationsTest {
-    operations: Vec<Option<NullableOperation>>,
+    operations: Vec<Option<UncheckedOperation>>,
     construction: bool,
 }
 
 #[test]
 fn test_operations_validations() {
-    let valid_deposit_amt = Some(NullableAmount {
+    let valid_deposit_amt = Some(UncheckedAmount {
         value: "1000".into(),
-        currency: Some(NullableCurrency {
+        currency: Some(UncheckedCurrency {
             symbol: "BTC".into(),
             decimals: 8,
             metadata: Default::default(),
         }),
         metadata: Default::default(),
     });
-    let valid_withdraw_amt = Some(NullableAmount {
+    let valid_withdraw_amt = Some(UncheckedAmount {
         value: "-1000".into(),
-        currency: Some(NullableCurrency {
+        currency: Some(UncheckedCurrency {
             symbol: "BTC".into(),
             decimals: 8,
             metadata: Default::default(),
         }),
         metadata: Default::default(),
     });
-    let valid_fee_amt = Some(NullableAmount {
+    let valid_fee_amt = Some(UncheckedAmount {
         value: "-100".into(),
-        currency: Some(NullableCurrency {
+        currency: Some(UncheckedCurrency {
             symbol: "BTC".into(),
             decimals: 8,
             metadata: Default::default(),
         }),
         metadata: Default::default(),
     });
-    let invalid_fee_amt = Some(NullableAmount {
+    let invalid_fee_amt = Some(UncheckedAmount {
         value: "100".into(),
-        currency: Some(NullableCurrency {
+        currency: Some(UncheckedCurrency {
             symbol: "BTC".into(),
             decimals: 8,
             metadata: Default::default(),
@@ -355,13 +355,13 @@ fn test_operations_validations() {
                 network: "WORLD".into(),
                 sub_network_identifier: None,
             }),
-            Some(NullableNetworkStatusResponse {
-                current_block_identifier: Some(NullableBlockIdentifier {
+            Some(UncheckedNetworkStatusResponse {
+                current_block_identifier: Some(UncheckedBlockIdentifier {
                     index: 100,
                     hash: "block 100".into(),
                 }),
                 current_block_timestamp: MIN_UNIX_EPOCH + 1,
-                genesis_block_identifier: Some(NullableBlockIdentifier {
+                genesis_block_identifier: Some(UncheckedBlockIdentifier {
                     index: 0,
                     hash: "block 0".into(),
                 }),
@@ -372,14 +372,14 @@ fn test_operations_validations() {
                     metadata: Default::default(),
                 })],
             }),
-            Some(NullableNetworkOptionsResponse {
+            Some(UncheckedNetworkOptionsResponse {
                 version: Some(Version {
                     rosetta_version: "1.4.0".into(),
                     node_version: "1.0".into(),
                     middleware_version: None,
                     metadata: Default::default(),
                 }),
-                allow: Some(NullableAllow {
+                allow: Some(UncheckedAllow {
                     operation_statuses: vec![
                         Some(OperationStatus {
                             status: "SUCCESS".into(),
@@ -406,8 +406,8 @@ fn test_operations_validations() {
                 caller: asserter(Path::new("validation_fee_and_payment_balanced.json")),
                 payload: OperationValidationsTest {
                     operations: vec![
-                        Some(NullableOperation {
-                            operation_identifier: Some(NullableOperationIdentifier {
+                        Some(UncheckedOperation {
+                            operation_identifier: Some(UncheckedOperationIdentifier {
                                 index: 0,
                                 network_index: None,
                             }),
@@ -417,8 +417,8 @@ fn test_operations_validations() {
                             amount: valid_deposit_amt.clone(),
                             ..Default::default()
                         }),
-                        Some(NullableOperation {
-                            operation_identifier: Some(NullableOperationIdentifier {
+                        Some(UncheckedOperation {
+                            operation_identifier: Some(UncheckedOperationIdentifier {
                                 index: 1,
                                 network_index: None,
                             }),
@@ -428,8 +428,8 @@ fn test_operations_validations() {
                             amount: valid_withdraw_amt.clone(),
                             ..Default::default()
                         }),
-                        Some(NullableOperation {
-                            operation_identifier: Some(NullableOperationIdentifier {
+                        Some(UncheckedOperation {
+                            operation_identifier: Some(UncheckedOperationIdentifier {
                                 index: 2,
                                 network_index: None,
                             }),
@@ -451,8 +451,8 @@ fn test_operations_validations() {
                 caller: asserter(Path::new("validation_fee_and_payment_balanced.json")),
                 payload: OperationValidationsTest {
                     operations: vec![
-                        Some(NullableOperation {
-                            operation_identifier: Some(NullableOperationIdentifier {
+                        Some(UncheckedOperation {
+                            operation_identifier: Some(UncheckedOperationIdentifier {
                                 index: 0,
                                 network_index: None,
                             }),
@@ -462,8 +462,8 @@ fn test_operations_validations() {
                             amount: valid_deposit_amt.clone(),
                             ..Default::default()
                         }),
-                        Some(NullableOperation {
-                            operation_identifier: Some(NullableOperationIdentifier {
+                        Some(UncheckedOperation {
+                            operation_identifier: Some(UncheckedOperationIdentifier {
                                 index: 1,
                                 network_index: None,
                             }),
@@ -485,8 +485,8 @@ fn test_operations_validations() {
                 caller: asserter(Path::new("validation_fee_and_payment_balanced.json")),
                 payload: OperationValidationsTest {
                     operations: vec![
-                        Some(NullableOperation {
-                            operation_identifier: Some(NullableOperationIdentifier {
+                        Some(UncheckedOperation {
+                            operation_identifier: Some(UncheckedOperationIdentifier {
                                 index: 0,
                                 network_index: None,
                             }),
@@ -496,8 +496,8 @@ fn test_operations_validations() {
                             amount: valid_deposit_amt.clone(),
                             ..Default::default()
                         }),
-                        Some(NullableOperation {
-                            operation_identifier: Some(NullableOperationIdentifier {
+                        Some(UncheckedOperation {
+                            operation_identifier: Some(UncheckedOperationIdentifier {
                                 index: 1,
                                 network_index: None,
                             }),
@@ -519,8 +519,8 @@ fn test_operations_validations() {
                 caller: asserter(Path::new("validation_fee_and_payment_balanced.json")),
                 payload: OperationValidationsTest {
                     operations: vec![
-                        Some(NullableOperation {
-                            operation_identifier: Some(NullableOperationIdentifier {
+                        Some(UncheckedOperation {
+                            operation_identifier: Some(UncheckedOperationIdentifier {
                                 index: 0,
                                 network_index: None,
                             }),
@@ -530,17 +530,17 @@ fn test_operations_validations() {
                             amount: valid_deposit_amt.clone(),
                             ..Default::default()
                         }),
-                        Some(NullableOperation {
-                            operation_identifier: Some(NullableOperationIdentifier {
+                        Some(UncheckedOperation {
+                            operation_identifier: Some(UncheckedOperationIdentifier {
                                 index: 1,
                                 network_index: None,
                             }),
                             type_: "PAYMENT".into(),
                             status: Some("SUCCESS".into()),
                             account: valid_account.clone(),
-                            amount: Some(NullableAmount {
+                            amount: Some(UncheckedAmount {
                                 value: "-2000".into(),
-                                currency: Some(NullableCurrency {
+                                currency: Some(UncheckedCurrency {
                                     symbol: "BTC".into(),
                                     decimals: 8,
                                     metadata: Default::default(),
@@ -549,8 +549,8 @@ fn test_operations_validations() {
                             }),
                             ..Default::default()
                         }),
-                        Some(NullableOperation {
-                            operation_identifier: Some(NullableOperationIdentifier {
+                        Some(UncheckedOperation {
+                            operation_identifier: Some(UncheckedOperationIdentifier {
                                 index: 2,
                                 network_index: None,
                             }),
@@ -572,8 +572,8 @@ fn test_operations_validations() {
                 caller: asserter(Path::new("validation_fee_and_payment_unbalanced.json")),
                 payload: OperationValidationsTest {
                     operations: vec![
-                        Some(NullableOperation {
-                            operation_identifier: Some(NullableOperationIdentifier {
+                        Some(UncheckedOperation {
+                            operation_identifier: Some(UncheckedOperationIdentifier {
                                 index: 0,
                                 network_index: None,
                             }),
@@ -583,17 +583,17 @@ fn test_operations_validations() {
                             amount: valid_deposit_amt.clone(),
                             ..Default::default()
                         }),
-                        Some(NullableOperation {
-                            operation_identifier: Some(NullableOperationIdentifier {
+                        Some(UncheckedOperation {
+                            operation_identifier: Some(UncheckedOperationIdentifier {
                                 index: 1,
                                 network_index: None,
                             }),
                             type_: "PAYMENT".into(),
                             status: Some("SUCCESS".into()),
                             account: valid_account.clone(),
-                            amount: Some(NullableAmount {
+                            amount: Some(UncheckedAmount {
                                 value: "-2000".into(),
-                                currency: Some(NullableCurrency {
+                                currency: Some(UncheckedCurrency {
                                     symbol: "BTC".into(),
                                     decimals: 8,
                                     metadata: Default::default(),
@@ -602,8 +602,8 @@ fn test_operations_validations() {
                             }),
                             ..Default::default()
                         }),
-                        Some(NullableOperation {
-                            operation_identifier: Some(NullableOperationIdentifier {
+                        Some(UncheckedOperation {
+                            operation_identifier: Some(UncheckedOperationIdentifier {
                                 index: 2,
                                 network_index: None,
                             }),
@@ -625,8 +625,8 @@ fn test_operations_validations() {
                 caller: asserter(Path::new("validation_fee_and_payment_unbalanced.json")),
                 payload: OperationValidationsTest {
                     operations: vec![
-                        Some(NullableOperation {
-                            operation_identifier: Some(NullableOperationIdentifier {
+                        Some(UncheckedOperation {
+                            operation_identifier: Some(UncheckedOperationIdentifier {
                                 index: 0,
                                 network_index: None,
                             }),
@@ -636,17 +636,17 @@ fn test_operations_validations() {
                             amount: valid_deposit_amt.clone(),
                             ..Default::default()
                         }),
-                        Some(NullableOperation {
-                            operation_identifier: Some(NullableOperationIdentifier {
+                        Some(UncheckedOperation {
+                            operation_identifier: Some(UncheckedOperationIdentifier {
                                 index: 1,
                                 network_index: None,
                             }),
                             type_: "PAYMENT".into(),
                             status: Some("SUCCESS".into()),
                             account: valid_account.clone(),
-                            amount: Some(NullableAmount {
+                            amount: Some(UncheckedAmount {
                                 value: "-2000".into(),
-                                currency: Some(NullableCurrency {
+                                currency: Some(UncheckedCurrency {
                                     symbol: "BTC".into(),
                                     decimals: 8,
                                     metadata: Default::default(),
@@ -655,8 +655,8 @@ fn test_operations_validations() {
                             }),
                             ..Default::default()
                         }),
-                        Some(NullableOperation {
-                            operation_identifier: Some(NullableOperationIdentifier {
+                        Some(UncheckedOperation {
+                            operation_identifier: Some(UncheckedOperationIdentifier {
                                 index: 2,
                                 network_index: None,
                             }),
@@ -664,7 +664,7 @@ fn test_operations_validations() {
                             status: Some("SUCCESS".into()),
                             account: valid_account.clone(),
                             amount: valid_fee_amt.clone(),
-                            related_operations: vec![Some(NullableOperationIdentifier {
+                            related_operations: vec![Some(UncheckedOperationIdentifier {
                                 index: 0,
                                 network_index: None,
                             })],
@@ -682,8 +682,8 @@ fn test_operations_validations() {
                 caller: asserter(Path::new("validation_fee_and_payment_unbalanced.json")),
                 payload: OperationValidationsTest {
                     operations: vec![
-                        Some(NullableOperation {
-                            operation_identifier: Some(NullableOperationIdentifier {
+                        Some(UncheckedOperation {
+                            operation_identifier: Some(UncheckedOperationIdentifier {
                                 index: 0,
                                 network_index: None,
                             }),
@@ -693,17 +693,17 @@ fn test_operations_validations() {
                             amount: valid_deposit_amt.clone(),
                             ..Default::default()
                         }),
-                        Some(NullableOperation {
-                            operation_identifier: Some(NullableOperationIdentifier {
+                        Some(UncheckedOperation {
+                            operation_identifier: Some(UncheckedOperationIdentifier {
                                 index: 1,
                                 network_index: None,
                             }),
                             type_: "PAYMENT".into(),
                             status: Some("SUCCESS".into()),
                             account: valid_account.clone(),
-                            amount: Some(NullableAmount {
+                            amount: Some(UncheckedAmount {
                                 value: "-2000".into(),
-                                currency: Some(NullableCurrency {
+                                currency: Some(UncheckedCurrency {
                                     symbol: "BTC".into(),
                                     decimals: 8,
                                     metadata: Default::default(),
@@ -712,8 +712,8 @@ fn test_operations_validations() {
                             }),
                             ..Default::default()
                         }),
-                        Some(NullableOperation {
-                            operation_identifier: Some(NullableOperationIdentifier {
+                        Some(UncheckedOperation {
+                            operation_identifier: Some(UncheckedOperationIdentifier {
                                 index: 2,
                                 network_index: None,
                             }),
@@ -735,8 +735,8 @@ fn test_operations_validations() {
                 caller: asserter(Path::new("validation_fee_and_payment_unbalanced.json")),
                 payload: OperationValidationsTest {
                     operations: vec![
-                        Some(NullableOperation {
-                            operation_identifier: Some(NullableOperationIdentifier {
+                        Some(UncheckedOperation {
+                            operation_identifier: Some(UncheckedOperationIdentifier {
                                 index: 0,
                                 network_index: None,
                             }),
@@ -746,17 +746,17 @@ fn test_operations_validations() {
                             amount: valid_deposit_amt,
                             ..Default::default()
                         }),
-                        Some(NullableOperation {
-                            operation_identifier: Some(NullableOperationIdentifier {
+                        Some(UncheckedOperation {
+                            operation_identifier: Some(UncheckedOperationIdentifier {
                                 index: 1,
                                 network_index: None,
                             }),
                             type_: "PAYMENT".into(),
                             status: Some("SUCCESS".into()),
                             account: valid_account.clone(),
-                            amount: Some(NullableAmount {
+                            amount: Some(UncheckedAmount {
                                 value: "-2000".into(),
-                                currency: Some(NullableCurrency {
+                                currency: Some(UncheckedCurrency {
                                     symbol: "BTC".into(),
                                     decimals: 8,
                                     metadata: Default::default(),
@@ -765,8 +765,8 @@ fn test_operations_validations() {
                             }),
                             ..Default::default()
                         }),
-                        Some(NullableOperation {
-                            operation_identifier: Some(NullableOperationIdentifier {
+                        Some(UncheckedOperation {
+                            operation_identifier: Some(UncheckedOperationIdentifier {
                                 index: 2,
                                 network_index: None,
                             }),
@@ -792,7 +792,7 @@ fn test_operations_validations() {
 
 #[derive(Default)]
 struct OperationTest {
-    operation: Option<NullableOperation>,
+    operation: Option<UncheckedOperation>,
     index: isize,
     successful: bool,
     construction: bool,
@@ -800,9 +800,9 @@ struct OperationTest {
 
 #[test]
 fn test_operation() {
-    let valid_amount = Some(NullableAmount {
+    let valid_amount = Some(UncheckedAmount {
         value: "1000".into(),
-        currency: Some(NullableCurrency {
+        currency: Some(UncheckedCurrency {
             symbol: "BTC".into(),
             decimals: 8,
             metadata: Default::default(),
@@ -818,8 +818,8 @@ fn test_operation() {
         TestCase {
             name: "valid operation",
             payload: OperationTest {
-                operation: Some(NullableOperation {
-                    operation_identifier: Some(NullableOperationIdentifier {
+                operation: Some(UncheckedOperation {
+                    operation_identifier: Some(UncheckedOperationIdentifier {
                         index: 1,
                         network_index: None,
                     }),
@@ -838,8 +838,8 @@ fn test_operation() {
         TestCase {
             name: "valid operation no account",
             payload: OperationTest {
-                operation: Some(NullableOperation {
-                    operation_identifier: Some(NullableOperationIdentifier {
+                operation: Some(UncheckedOperation {
+                    operation_identifier: Some(UncheckedOperationIdentifier {
                         index: 1,
                         network_index: None,
                     }),
@@ -866,8 +866,8 @@ fn test_operation() {
         TestCase {
             name: "invalid operation no account",
             payload: OperationTest {
-                operation: Some(NullableOperation {
-                    operation_identifier: Some(NullableOperationIdentifier {
+                operation: Some(UncheckedOperation {
+                    operation_identifier: Some(UncheckedOperationIdentifier {
                         index: 1,
                         network_index: None,
                     }),
@@ -885,8 +885,8 @@ fn test_operation() {
         TestCase {
             name: "invalid operation empty account",
             payload: OperationTest {
-                operation: Some(NullableOperation {
-                    operation_identifier: Some(NullableOperationIdentifier {
+                operation: Some(UncheckedOperation {
+                    operation_identifier: Some(UncheckedOperationIdentifier {
                         index: 1,
                         network_index: None,
                     }),
@@ -905,8 +905,8 @@ fn test_operation() {
         TestCase {
             name: "invalid operation invalid index",
             payload: OperationTest {
-                operation: Some(NullableOperation {
-                    operation_identifier: Some(NullableOperationIdentifier {
+                operation: Some(UncheckedOperation {
+                    operation_identifier: Some(UncheckedOperationIdentifier {
                         index: 1,
                         network_index: None,
                     }),
@@ -923,8 +923,8 @@ fn test_operation() {
         TestCase {
             name: "invalid operation invalid type",
             payload: OperationTest {
-                operation: Some(NullableOperation {
-                    operation_identifier: Some(NullableOperationIdentifier {
+                operation: Some(UncheckedOperation {
+                    operation_identifier: Some(UncheckedOperationIdentifier {
                         index: 1,
                         network_index: None,
                     }),
@@ -941,8 +941,8 @@ fn test_operation() {
         TestCase {
             name: "unsuccessful operation",
             payload: OperationTest {
-                operation: Some(NullableOperation {
-                    operation_identifier: Some(NullableOperationIdentifier {
+                operation: Some(UncheckedOperation {
+                    operation_identifier: Some(UncheckedOperationIdentifier {
                         index: 1,
                         network_index: None,
                     }),
@@ -959,8 +959,8 @@ fn test_operation() {
         TestCase {
             name: "invalid operation invalid status",
             payload: OperationTest {
-                operation: Some(NullableOperation {
-                    operation_identifier: Some(NullableOperationIdentifier {
+                operation: Some(UncheckedOperation {
+                    operation_identifier: Some(UncheckedOperationIdentifier {
                         index: 1,
                         network_index: None,
                     }),
@@ -977,8 +977,8 @@ fn test_operation() {
         TestCase {
             name: "valid construction operation",
             payload: OperationTest {
-                operation: Some(NullableOperation {
-                    operation_identifier: Some(NullableOperationIdentifier {
+                operation: Some(UncheckedOperation {
+                    operation_identifier: Some(UncheckedOperationIdentifier {
                         index: 1,
                         network_index: None,
                     }),
@@ -996,8 +996,8 @@ fn test_operation() {
         TestCase {
             name: "valid construction operation (empty status)",
             payload: OperationTest {
-                operation: Some(NullableOperation {
-                    operation_identifier: Some(NullableOperationIdentifier {
+                operation: Some(UncheckedOperation {
+                    operation_identifier: Some(UncheckedOperationIdentifier {
                         index: 1,
                         network_index: None,
                     }),
@@ -1016,8 +1016,8 @@ fn test_operation() {
         TestCase {
             name: "invalid construction operation",
             payload: OperationTest {
-                operation: Some(NullableOperation {
-                    operation_identifier: Some(NullableOperationIdentifier {
+                operation: Some(UncheckedOperation {
+                    operation_identifier: Some(UncheckedOperationIdentifier {
                         index: 1,
                         network_index: None,
                     }),
@@ -1041,13 +1041,13 @@ fn test_operation() {
             network: "WORLD".into(),
             sub_network_identifier: None,
         }),
-        Some(NullableNetworkStatusResponse {
-            current_block_identifier: Some(NullableBlockIdentifier {
+        Some(UncheckedNetworkStatusResponse {
+            current_block_identifier: Some(UncheckedBlockIdentifier {
                 index: 100,
                 hash: "block 100".into(),
             }),
             current_block_timestamp: MIN_UNIX_EPOCH + 1,
-            genesis_block_identifier: Some(NullableBlockIdentifier {
+            genesis_block_identifier: Some(UncheckedBlockIdentifier {
                 index: 0,
                 hash: "block 0".into(),
             }),
@@ -1058,14 +1058,14 @@ fn test_operation() {
                 metadata: Default::default(),
             })],
         }),
-        Some(NullableNetworkOptionsResponse {
+        Some(UncheckedNetworkOptionsResponse {
             version: Some(Version {
                 rosetta_version: "1.4.0".into(),
                 node_version: "1.0".into(),
                 middleware_version: None,
                 metadata: Default::default(),
             }),
-            allow: Some(NullableAllow {
+            allow: Some(UncheckedAllow {
                 operation_statuses: vec![
                     Some(OperationStatus {
                         status: "SUCCESS".into(),
@@ -1132,21 +1132,21 @@ struct BlockTestExtras {
 
 #[test]
 fn test_block() {
-    let genesis_ident = NullableBlockIdentifier {
+    let genesis_ident = UncheckedBlockIdentifier {
         hash: "gen".into(),
         index: 0,
     };
-    let valid_block_ident = NullableBlockIdentifier {
+    let valid_block_ident = UncheckedBlockIdentifier {
         hash: "blah".into(),
         index: 100,
     };
-    let valid_parent_block_ident = NullableBlockIdentifier {
+    let valid_parent_block_ident = UncheckedBlockIdentifier {
         hash: "blah parent".into(),
         index: 99,
     };
-    let valid_amount = Some(NullableAmount {
+    let valid_amount = Some(UncheckedAmount {
         value: "1000".into(),
-        currency: Some(NullableCurrency {
+        currency: Some(UncheckedCurrency {
             symbol: "BTC".into(),
             decimals: 8,
             metadata: Default::default(),
@@ -1157,13 +1157,13 @@ fn test_block() {
         address: "test".into(),
         ..Default::default()
     });
-    let valid_transaction = Some(NullableTransaction {
+    let valid_transaction = Some(UncheckedTransaction {
         transaction_identifier: Some(TransactionIdentifier {
             hash: "blah".into(),
         }),
         operations: vec![
-            Some(NullableOperation {
-                operation_identifier: Some(NullableOperationIdentifier {
+            Some(UncheckedOperation {
+                operation_identifier: Some(UncheckedOperationIdentifier {
                     index: 0,
                     network_index: None,
                 }),
@@ -1173,12 +1173,12 @@ fn test_block() {
                 amount: valid_amount.clone(),
                 ..Default::default()
             }),
-            Some(NullableOperation {
-                operation_identifier: Some(NullableOperationIdentifier {
+            Some(UncheckedOperation {
+                operation_identifier: Some(UncheckedOperationIdentifier {
                     index: 1,
                     network_index: None,
                 }),
-                related_operations: vec![Some(NullableOperationIdentifier {
+                related_operations: vec![Some(UncheckedOperationIdentifier {
                     index: 0,
                     network_index: None,
                 })],
@@ -1189,7 +1189,7 @@ fn test_block() {
                 ..Default::default()
             }),
         ],
-        related_transactions: vec![Some(NullableRelatedTransaction {
+        related_transactions: vec![Some(UncheckedRelatedTransaction {
             network_identifier: Some(NetworkIdentifier {
                 blockchain: "HELLO".into(),
                 network: "WORLD".into(),
@@ -1198,20 +1198,20 @@ fn test_block() {
             transaction_identifier: Some(TransactionIdentifier {
                 hash: "blah".into(),
             }),
-            direction: NullableDirection::FORWARD.into(),
+            direction: UncheckedDirection::FORWARD.into(),
         })],
         metadata: Default::default(),
     });
-    let related_to_self_transaction = Some(NullableTransaction {
+    let related_to_self_transaction = Some(UncheckedTransaction {
         transaction_identifier: Some(TransactionIdentifier {
             hash: "blah".into(),
         }),
-        operations: vec![Some(NullableOperation {
-            operation_identifier: Some(NullableOperationIdentifier {
+        operations: vec![Some(UncheckedOperation {
+            operation_identifier: Some(UncheckedOperationIdentifier {
                 index: 0,
                 network_index: None,
             }),
-            related_operations: vec![Some(NullableOperationIdentifier {
+            related_operations: vec![Some(UncheckedOperationIdentifier {
                 index: 0,
                 network_index: None,
             })],
@@ -1223,17 +1223,17 @@ fn test_block() {
         })],
         ..Default::default()
     });
-    let out_of_order_transaction = Some(NullableTransaction {
+    let out_of_order_transaction = Some(UncheckedTransaction {
         transaction_identifier: Some(TransactionIdentifier {
             hash: "blah".into(),
         }),
         operations: vec![
-            Some(NullableOperation {
-                operation_identifier: Some(NullableOperationIdentifier {
+            Some(UncheckedOperation {
+                operation_identifier: Some(UncheckedOperationIdentifier {
                     index: 1,
                     network_index: None,
                 }),
-                related_operations: vec![Some(NullableOperationIdentifier {
+                related_operations: vec![Some(UncheckedOperationIdentifier {
                     index: 0,
                     network_index: None,
                 })],
@@ -1243,8 +1243,8 @@ fn test_block() {
                 amount: valid_amount.clone(),
                 ..Default::default()
             }),
-            Some(NullableOperation {
-                operation_identifier: Some(NullableOperationIdentifier {
+            Some(UncheckedOperation {
+                operation_identifier: Some(UncheckedOperationIdentifier {
                     index: 0,
                     network_index: None,
                 }),
@@ -1257,17 +1257,17 @@ fn test_block() {
         ],
         ..Default::default()
     });
-    let related_to_later_transaction = Some(NullableTransaction {
+    let related_to_later_transaction = Some(UncheckedTransaction {
         transaction_identifier: Some(TransactionIdentifier {
             hash: "blah".into(),
         }),
         operations: vec![
-            Some(NullableOperation {
-                operation_identifier: Some(NullableOperationIdentifier {
+            Some(UncheckedOperation {
+                operation_identifier: Some(UncheckedOperationIdentifier {
                     index: 0,
                     network_index: None,
                 }),
-                related_operations: vec![Some(NullableOperationIdentifier {
+                related_operations: vec![Some(UncheckedOperationIdentifier {
                     index: 1,
                     network_index: None,
                 })],
@@ -1277,12 +1277,12 @@ fn test_block() {
                 amount: valid_amount.clone(),
                 ..Default::default()
             }),
-            Some(NullableOperation {
-                operation_identifier: Some(NullableOperationIdentifier {
+            Some(UncheckedOperation {
+                operation_identifier: Some(UncheckedOperationIdentifier {
                     index: 1,
                     network_index: None,
                 }),
-                related_operations: vec![Some(NullableOperationIdentifier {
+                related_operations: vec![Some(UncheckedOperationIdentifier {
                     index: 0,
                     network_index: None,
                 })],
@@ -1295,13 +1295,13 @@ fn test_block() {
         ],
         ..Default::default()
     });
-    let related_duplicate_transaction = Some(NullableTransaction {
+    let related_duplicate_transaction = Some(UncheckedTransaction {
         transaction_identifier: Some(TransactionIdentifier {
             hash: "blah".into(),
         }),
         operations: vec![
-            Some(NullableOperation {
-                operation_identifier: Some(NullableOperationIdentifier {
+            Some(UncheckedOperation {
+                operation_identifier: Some(UncheckedOperationIdentifier {
                     index: 0,
                     network_index: None,
                 }),
@@ -1311,17 +1311,17 @@ fn test_block() {
                 amount: valid_amount.clone(),
                 ..Default::default()
             }),
-            Some(NullableOperation {
-                operation_identifier: Some(NullableOperationIdentifier {
+            Some(UncheckedOperation {
+                operation_identifier: Some(UncheckedOperationIdentifier {
                     index: 1,
                     network_index: None,
                 }),
                 related_operations: vec![
-                    Some(NullableOperationIdentifier {
+                    Some(UncheckedOperationIdentifier {
                         index: 0,
                         network_index: None,
                     }),
-                    Some(NullableOperationIdentifier {
+                    Some(UncheckedOperationIdentifier {
                         index: 0,
                         network_index: None,
                     }),
@@ -1335,13 +1335,13 @@ fn test_block() {
         ],
         ..Default::default()
     });
-    let related_missing_transaction = Some(NullableTransaction {
+    let related_missing_transaction = Some(UncheckedTransaction {
         transaction_identifier: Some(TransactionIdentifier {
             hash: "blah".into(),
         }),
         operations: vec![
-            Some(NullableOperation {
-                operation_identifier: Some(NullableOperationIdentifier {
+            Some(UncheckedOperation {
+                operation_identifier: Some(UncheckedOperationIdentifier {
                     index: 0,
                     network_index: None,
                 }),
@@ -1351,8 +1351,8 @@ fn test_block() {
                 amount: valid_amount.clone(),
                 ..Default::default()
             }),
-            Some(NullableOperation {
-                operation_identifier: Some(NullableOperationIdentifier {
+            Some(UncheckedOperation {
+                operation_identifier: Some(UncheckedOperationIdentifier {
                     index: 1,
                     network_index: None,
                 }),
@@ -1362,8 +1362,8 @@ fn test_block() {
                 amount: valid_amount.clone(),
                 ..Default::default()
             }),
-            Some(NullableOperation {
-                operation_identifier: Some(NullableOperationIdentifier {
+            Some(UncheckedOperation {
+                operation_identifier: Some(UncheckedOperationIdentifier {
                     index: 2,
                     network_index: None,
                 }),
@@ -1376,13 +1376,13 @@ fn test_block() {
         ],
         ..Default::default()
     });
-    let invalid_related_transaction = Some(NullableTransaction {
+    let invalid_related_transaction = Some(UncheckedTransaction {
         transaction_identifier: Some(TransactionIdentifier {
             hash: "blah".into(),
         }),
         operations: vec![
-            Some(NullableOperation {
-                operation_identifier: Some(NullableOperationIdentifier {
+            Some(UncheckedOperation {
+                operation_identifier: Some(UncheckedOperationIdentifier {
                     index: 0,
                     network_index: None,
                 }),
@@ -1392,12 +1392,12 @@ fn test_block() {
                 amount: valid_amount.clone(),
                 ..Default::default()
             }),
-            Some(NullableOperation {
-                operation_identifier: Some(NullableOperationIdentifier {
+            Some(UncheckedOperation {
+                operation_identifier: Some(UncheckedOperationIdentifier {
                     index: 1,
                     network_index: None,
                 }),
-                related_operations: vec![Some(NullableOperationIdentifier {
+                related_operations: vec![Some(UncheckedOperationIdentifier {
                     index: 0,
                     network_index: None,
                 })],
@@ -1408,7 +1408,7 @@ fn test_block() {
                 ..Default::default()
             }),
         ],
-        related_transactions: vec![Some(NullableRelatedTransaction {
+        related_transactions: vec![Some(UncheckedRelatedTransaction {
             network_identifier: Some(NetworkIdentifier {
                 blockchain: "HELLO".into(),
                 network: "WORLD".into(),
@@ -1421,13 +1421,13 @@ fn test_block() {
         })],
         ..Default::default()
     });
-    let duplicated_related_transactions = Some(NullableTransaction {
+    let duplicated_related_transactions = Some(UncheckedTransaction {
         transaction_identifier: Some(TransactionIdentifier {
             hash: "blah".into(),
         }),
         operations: vec![
-            Some(NullableOperation {
-                operation_identifier: Some(NullableOperationIdentifier {
+            Some(UncheckedOperation {
+                operation_identifier: Some(UncheckedOperationIdentifier {
                     index: 0,
                     network_index: None,
                 }),
@@ -1437,12 +1437,12 @@ fn test_block() {
                 amount: valid_amount.clone(),
                 ..Default::default()
             }),
-            Some(NullableOperation {
-                operation_identifier: Some(NullableOperationIdentifier {
+            Some(UncheckedOperation {
+                operation_identifier: Some(UncheckedOperationIdentifier {
                     index: 1,
                     network_index: None,
                 }),
-                related_operations: vec![Some(NullableOperationIdentifier {
+                related_operations: vec![Some(UncheckedOperationIdentifier {
                     index: 0,
                     network_index: None,
                 })],
@@ -1454,7 +1454,7 @@ fn test_block() {
             }),
         ],
         related_transactions: vec![
-            Some(NullableRelatedTransaction {
+            Some(UncheckedRelatedTransaction {
                 network_identifier: Some(NetworkIdentifier {
                     blockchain: "HELLO".into(),
                     network: "WORLD".into(),
@@ -1465,7 +1465,7 @@ fn test_block() {
                 }),
                 direction: "Forward".into(),
             }),
-            Some(NullableRelatedTransaction {
+            Some(UncheckedRelatedTransaction {
                 network_identifier: Some(NetworkIdentifier {
                     blockchain: "HELLO".into(),
                     network: "WORLD".into(),
@@ -1487,13 +1487,13 @@ fn test_block() {
                 network: "WORLD".into(),
                 sub_network_identifier: None,
             }),
-            Some(NullableNetworkStatusResponse {
-                current_block_identifier: Some(NullableBlockIdentifier {
+            Some(UncheckedNetworkStatusResponse {
+                current_block_identifier: Some(UncheckedBlockIdentifier {
                     index: 100,
                     hash: "block 100".into(),
                 }),
                 current_block_timestamp: MIN_UNIX_EPOCH + 1,
-                genesis_block_identifier: Some(NullableBlockIdentifier {
+                genesis_block_identifier: Some(UncheckedBlockIdentifier {
                     index: extras.genesis_index,
                     hash: format!("block {}", extras.genesis_index),
                 }),
@@ -1504,14 +1504,14 @@ fn test_block() {
                     metadata: Default::default(),
                 })],
             }),
-            Some(NullableNetworkOptionsResponse {
+            Some(UncheckedNetworkOptionsResponse {
                 version: Some(Version {
                     rosetta_version: "1.4.0".into(),
                     node_version: "1.0".into(),
                     middleware_version: None,
                     metadata: Default::default(),
                 }),
-                allow: Some(NullableAllow {
+                allow: Some(UncheckedAllow {
                     operation_statuses: vec![
                         Some(OperationStatus {
                             status: "SUCCESS".into(),
@@ -1537,7 +1537,7 @@ fn test_block() {
             name: "valid block",
             payload: MethodPayload {
                 caller: asserter(Default::default()),
-                payload: Some(NullableBlock {
+                payload: Some(UncheckedBlock {
                     block_identifier: Some(valid_block_ident.clone()),
                     parent_block_identifier: Some(valid_parent_block_ident.clone()),
                     timestamp: (MIN_UNIX_EPOCH + 1),
@@ -1554,7 +1554,7 @@ fn test_block() {
                     start_index: Some(valid_block_ident.index + 1),
                     ..Default::default()
                 }),
-                payload: Some(NullableBlock {
+                payload: Some(UncheckedBlock {
                     block_identifier: Some(valid_block_ident.clone()),
                     parent_block_identifier: Some(valid_parent_block_ident.clone()),
                     transactions: vec![valid_transaction.clone()],
@@ -1570,7 +1570,7 @@ fn test_block() {
                     genesis_index: valid_block_ident.index,
                     ..Default::default()
                 }),
-                payload: Some(NullableBlock {
+                payload: Some(UncheckedBlock {
                     block_identifier: Some(valid_block_ident.clone()),
                     parent_block_identifier: Some(valid_parent_block_ident.clone()),
                     transactions: vec![valid_transaction.clone()],
@@ -1587,7 +1587,7 @@ fn test_block() {
                     start_index: Some(genesis_ident.index + 1),
                     ..Default::default()
                 }),
-                payload: Some(NullableBlock {
+                payload: Some(UncheckedBlock {
                     block_identifier: Some(genesis_ident.clone()),
                     parent_block_identifier: Some(genesis_ident.clone()),
                     transactions: vec![valid_transaction.clone()],
@@ -1604,7 +1604,7 @@ fn test_block() {
                     start_index: Some(genesis_ident.index),
                     ..Default::default()
                 }),
-                payload: Some(NullableBlock {
+                payload: Some(UncheckedBlock {
                     block_identifier: Some(genesis_ident.clone()),
                     parent_block_identifier: Some(genesis_ident),
                     transactions: vec![valid_transaction.clone()],
@@ -1617,7 +1617,7 @@ fn test_block() {
             name: "out of order transaction operations",
             payload: MethodPayload {
                 caller: asserter(Default::default()),
-                payload: Some(NullableBlock {
+                payload: Some(UncheckedBlock {
                     block_identifier: Some(valid_block_ident.clone()),
                     parent_block_identifier: Some(valid_parent_block_ident.clone()),
                     timestamp: (MIN_UNIX_EPOCH + 1),
@@ -1631,7 +1631,7 @@ fn test_block() {
             name: "related to self transaction operations",
             payload: MethodPayload {
                 caller: asserter(Default::default()),
-                payload: Some(NullableBlock {
+                payload: Some(UncheckedBlock {
                     block_identifier: Some(valid_block_ident.clone()),
                     parent_block_identifier: Some(valid_parent_block_ident.clone()),
                     timestamp: (MIN_UNIX_EPOCH + 1),
@@ -1645,7 +1645,7 @@ fn test_block() {
             name: "related to later transaction operations",
             payload: MethodPayload {
                 caller: asserter(Default::default()),
-                payload: Some(NullableBlock {
+                payload: Some(UncheckedBlock {
                     block_identifier: Some(valid_block_ident.clone()),
                     parent_block_identifier: Some(valid_parent_block_ident.clone()),
                     timestamp: (MIN_UNIX_EPOCH + 1),
@@ -1659,7 +1659,7 @@ fn test_block() {
             name: "duplicate related transaction operations",
             payload: MethodPayload {
                 caller: asserter(Default::default()),
-                payload: Some(NullableBlock {
+                payload: Some(UncheckedBlock {
                     block_identifier: Some(valid_block_ident.clone()),
                     parent_block_identifier: Some(valid_parent_block_ident.clone()),
                     timestamp: (MIN_UNIX_EPOCH + 1),
@@ -1678,7 +1678,7 @@ fn test_block() {
                     )),
                     ..Default::default()
                 }),
-                payload: Some(NullableBlock {
+                payload: Some(UncheckedBlock {
                     block_identifier: Some(valid_block_ident.clone()),
                     parent_block_identifier: Some(valid_parent_block_ident.clone()),
                     timestamp: (MIN_UNIX_EPOCH + 1),
@@ -1700,7 +1700,7 @@ fn test_block() {
             name: "nil block hash",
             payload: MethodPayload {
                 caller: asserter(Default::default()),
-                payload: Some(NullableBlock {
+                payload: Some(UncheckedBlock {
                     block_identifier: None,
                     parent_block_identifier: Some(valid_parent_block_ident.clone()),
                     timestamp: (MIN_UNIX_EPOCH + 1),
@@ -1714,7 +1714,7 @@ fn test_block() {
             name: "invalid block hash",
             payload: MethodPayload {
                 caller: asserter(Default::default()),
-                payload: Some(NullableBlock {
+                payload: Some(UncheckedBlock {
                     block_identifier: Some(Default::default()),
                     parent_block_identifier: Some(valid_parent_block_ident.clone()),
                     timestamp: (MIN_UNIX_EPOCH + 1),
@@ -1728,7 +1728,7 @@ fn test_block() {
             name: "block previous hash missing",
             payload: MethodPayload {
                 caller: asserter(Default::default()),
-                payload: Some(NullableBlock {
+                payload: Some(UncheckedBlock {
                     block_identifier: Some(valid_block_ident.clone()),
                     parent_block_identifier: Some(Default::default()),
                     timestamp: (MIN_UNIX_EPOCH + 1),
@@ -1742,9 +1742,9 @@ fn test_block() {
             name: "invalid parent block index",
             payload: MethodPayload {
                 caller: asserter(Default::default()),
-                payload: Some(NullableBlock {
+                payload: Some(UncheckedBlock {
                     block_identifier: Some(valid_block_ident.clone()),
-                    parent_block_identifier: Some(NullableBlockIdentifier {
+                    parent_block_identifier: Some(UncheckedBlockIdentifier {
                         index: valid_block_ident.index,
                         hash: valid_parent_block_ident.hash.clone(),
                     }),
@@ -1759,9 +1759,9 @@ fn test_block() {
             name: "invalid parent block hash",
             payload: MethodPayload {
                 caller: asserter(Default::default()),
-                payload: Some(NullableBlock {
+                payload: Some(UncheckedBlock {
                     block_identifier: Some(valid_block_ident.clone()),
-                    parent_block_identifier: Some(NullableBlockIdentifier {
+                    parent_block_identifier: Some(UncheckedBlockIdentifier {
                         index: valid_parent_block_ident.index,
                         hash: valid_block_ident.hash.clone(),
                     }),
@@ -1776,7 +1776,7 @@ fn test_block() {
             name: "invalid block timestamp less than MinUnixEpoch",
             payload: MethodPayload {
                 caller: asserter(Default::default()),
-                payload: Some(NullableBlock {
+                payload: Some(UncheckedBlock {
                     block_identifier: Some(valid_block_ident.clone()),
                     parent_block_identifier: Some(valid_parent_block_ident.clone()),
                     transactions: vec![valid_transaction.clone()],
@@ -1789,7 +1789,7 @@ fn test_block() {
             name: "invalid block timestamp greater than MaxUnixEpoch",
             payload: MethodPayload {
                 caller: asserter(Default::default()),
-                payload: Some(NullableBlock {
+                payload: Some(UncheckedBlock {
                     block_identifier: Some(valid_block_ident.clone()),
                     parent_block_identifier: Some(valid_parent_block_ident.clone()),
                     transactions: vec![valid_transaction],
@@ -1803,7 +1803,7 @@ fn test_block() {
             name: "invalid block transaction",
             payload: MethodPayload {
                 caller: asserter(Default::default()),
-                payload: Some(NullableBlock {
+                payload: Some(UncheckedBlock {
                     block_identifier: Some(valid_block_ident.clone()),
                     parent_block_identifier: Some(valid_parent_block_ident.clone()),
                     transactions: vec![Some(Default::default())],
@@ -1817,7 +1817,7 @@ fn test_block() {
             name: "invalid related transaction",
             payload: MethodPayload {
                 caller: asserter(Default::default()),
-                payload: Some(NullableBlock {
+                payload: Some(UncheckedBlock {
                     block_identifier: Some(valid_block_ident.clone()),
                     parent_block_identifier: Some(valid_parent_block_ident.clone()),
                     transactions: vec![invalid_related_transaction],
@@ -1831,7 +1831,7 @@ fn test_block() {
             name: "duplicate related transaction",
             payload: MethodPayload {
                 caller: asserter(Default::default()),
-                payload: Some(NullableBlock {
+                payload: Some(UncheckedBlock {
                     block_identifier: Some(valid_block_ident),
                     parent_block_identifier: Some(valid_parent_block_ident),
                     transactions: vec![duplicated_related_transactions],

--- a/crates/mentat-asserter/src/block_test.rs
+++ b/crates/mentat-asserter/src/block_test.rs
@@ -7,7 +7,7 @@ fn test_block_identifier() {
     let tests = vec![
         TestCase {
             name: "valid identifier",
-            payload: Some(BlockIdentifier {
+            payload: Some(NullableBlockIdentifier {
                 index: 1,
                 hash: "block 1".into(),
             }),
@@ -20,7 +20,7 @@ fn test_block_identifier() {
         },
         TestCase {
             name: "invalid index",
-            payload: Some(BlockIdentifier {
+            payload: Some(NullableBlockIdentifier {
                 index: -1,
                 hash: "block 1".into(),
             }),
@@ -28,7 +28,7 @@ fn test_block_identifier() {
         },
         TestCase {
             name: "invalid hash",
-            payload: Some(BlockIdentifier {
+            payload: Some(NullableBlockIdentifier {
                 index: 1,
                 hash: String::new(),
             }),
@@ -176,8 +176,8 @@ fn test_amount() {
 
 #[derive(Default)]
 struct OperationIdentTest {
-    ident: Option<OperationIdentifier>,
-    index: i64,
+    ident: Option<NullableOperationIdentifier>,
+    index: isize,
 }
 
 impl OperationIdentTest {
@@ -195,7 +195,7 @@ fn test_operation_identifier() {
         TestCase {
             name: "valid identifier",
             payload: Some(OperationIdentTest {
-                ident: Some(OperationIdentifier {
+                ident: Some(NullableOperationIdentifier {
                     index: 0,
                     network_index: None,
                 }),
@@ -214,7 +214,7 @@ fn test_operation_identifier() {
         TestCase {
             name: "out-of-order index",
             payload: Some(OperationIdentTest {
-                ident: Some(OperationIdentifier {
+                ident: Some(NullableOperationIdentifier {
                     index: 0,
                     network_index: None,
                 }),
@@ -225,7 +225,7 @@ fn test_operation_identifier() {
         TestCase {
             name: "valid identifier with network index",
             payload: Some(OperationIdentTest {
-                ident: Some(OperationIdentifier {
+                ident: Some(NullableOperationIdentifier {
                     index: 0,
                     network_index: Some(valid_network_index),
                 }),
@@ -236,7 +236,7 @@ fn test_operation_identifier() {
         TestCase {
             name: "invalid identifier with network index",
             payload: Some(OperationIdentTest {
-                ident: Some(OperationIdentifier {
+                ident: Some(NullableOperationIdentifier {
                     index: 0,
                     network_index: Some(invalid_network_index),
                 }),
@@ -356,12 +356,12 @@ fn test_operations_validations() {
                 sub_network_identifier: None,
             }),
             Some(NullableNetworkStatusResponse {
-                current_block_identifier: Some(BlockIdentifier {
+                current_block_identifier: Some(NullableBlockIdentifier {
                     index: 100,
                     hash: "block 100".into(),
                 }),
                 current_block_timestamp: MIN_UNIX_EPOCH + 1,
-                genesis_block_identifier: Some(BlockIdentifier {
+                genesis_block_identifier: Some(NullableBlockIdentifier {
                     index: 0,
                     hash: "block 0".into(),
                 }),
@@ -407,7 +407,7 @@ fn test_operations_validations() {
                 payload: OperationValidationsTest {
                     operations: vec![
                         Some(NullableOperation {
-                            operation_identifier: Some(OperationIdentifier {
+                            operation_identifier: Some(NullableOperationIdentifier {
                                 index: 0,
                                 network_index: None,
                             }),
@@ -418,7 +418,7 @@ fn test_operations_validations() {
                             ..Default::default()
                         }),
                         Some(NullableOperation {
-                            operation_identifier: Some(OperationIdentifier {
+                            operation_identifier: Some(NullableOperationIdentifier {
                                 index: 1,
                                 network_index: None,
                             }),
@@ -429,7 +429,7 @@ fn test_operations_validations() {
                             ..Default::default()
                         }),
                         Some(NullableOperation {
-                            operation_identifier: Some(OperationIdentifier {
+                            operation_identifier: Some(NullableOperationIdentifier {
                                 index: 2,
                                 network_index: None,
                             }),
@@ -452,7 +452,7 @@ fn test_operations_validations() {
                 payload: OperationValidationsTest {
                     operations: vec![
                         Some(NullableOperation {
-                            operation_identifier: Some(OperationIdentifier {
+                            operation_identifier: Some(NullableOperationIdentifier {
                                 index: 0,
                                 network_index: None,
                             }),
@@ -463,7 +463,7 @@ fn test_operations_validations() {
                             ..Default::default()
                         }),
                         Some(NullableOperation {
-                            operation_identifier: Some(OperationIdentifier {
+                            operation_identifier: Some(NullableOperationIdentifier {
                                 index: 1,
                                 network_index: None,
                             }),
@@ -486,7 +486,7 @@ fn test_operations_validations() {
                 payload: OperationValidationsTest {
                     operations: vec![
                         Some(NullableOperation {
-                            operation_identifier: Some(OperationIdentifier {
+                            operation_identifier: Some(NullableOperationIdentifier {
                                 index: 0,
                                 network_index: None,
                             }),
@@ -497,7 +497,7 @@ fn test_operations_validations() {
                             ..Default::default()
                         }),
                         Some(NullableOperation {
-                            operation_identifier: Some(OperationIdentifier {
+                            operation_identifier: Some(NullableOperationIdentifier {
                                 index: 1,
                                 network_index: None,
                             }),
@@ -520,7 +520,7 @@ fn test_operations_validations() {
                 payload: OperationValidationsTest {
                     operations: vec![
                         Some(NullableOperation {
-                            operation_identifier: Some(OperationIdentifier {
+                            operation_identifier: Some(NullableOperationIdentifier {
                                 index: 0,
                                 network_index: None,
                             }),
@@ -531,7 +531,7 @@ fn test_operations_validations() {
                             ..Default::default()
                         }),
                         Some(NullableOperation {
-                            operation_identifier: Some(OperationIdentifier {
+                            operation_identifier: Some(NullableOperationIdentifier {
                                 index: 1,
                                 network_index: None,
                             }),
@@ -550,7 +550,7 @@ fn test_operations_validations() {
                             ..Default::default()
                         }),
                         Some(NullableOperation {
-                            operation_identifier: Some(OperationIdentifier {
+                            operation_identifier: Some(NullableOperationIdentifier {
                                 index: 2,
                                 network_index: None,
                             }),
@@ -573,7 +573,7 @@ fn test_operations_validations() {
                 payload: OperationValidationsTest {
                     operations: vec![
                         Some(NullableOperation {
-                            operation_identifier: Some(OperationIdentifier {
+                            operation_identifier: Some(NullableOperationIdentifier {
                                 index: 0,
                                 network_index: None,
                             }),
@@ -584,7 +584,7 @@ fn test_operations_validations() {
                             ..Default::default()
                         }),
                         Some(NullableOperation {
-                            operation_identifier: Some(OperationIdentifier {
+                            operation_identifier: Some(NullableOperationIdentifier {
                                 index: 1,
                                 network_index: None,
                             }),
@@ -603,7 +603,7 @@ fn test_operations_validations() {
                             ..Default::default()
                         }),
                         Some(NullableOperation {
-                            operation_identifier: Some(OperationIdentifier {
+                            operation_identifier: Some(NullableOperationIdentifier {
                                 index: 2,
                                 network_index: None,
                             }),
@@ -626,7 +626,7 @@ fn test_operations_validations() {
                 payload: OperationValidationsTest {
                     operations: vec![
                         Some(NullableOperation {
-                            operation_identifier: Some(OperationIdentifier {
+                            operation_identifier: Some(NullableOperationIdentifier {
                                 index: 0,
                                 network_index: None,
                             }),
@@ -637,7 +637,7 @@ fn test_operations_validations() {
                             ..Default::default()
                         }),
                         Some(NullableOperation {
-                            operation_identifier: Some(OperationIdentifier {
+                            operation_identifier: Some(NullableOperationIdentifier {
                                 index: 1,
                                 network_index: None,
                             }),
@@ -656,7 +656,7 @@ fn test_operations_validations() {
                             ..Default::default()
                         }),
                         Some(NullableOperation {
-                            operation_identifier: Some(OperationIdentifier {
+                            operation_identifier: Some(NullableOperationIdentifier {
                                 index: 2,
                                 network_index: None,
                             }),
@@ -664,7 +664,7 @@ fn test_operations_validations() {
                             status: Some("SUCCESS".into()),
                             account: valid_account.clone(),
                             amount: valid_fee_amt.clone(),
-                            related_operations: vec![Some(OperationIdentifier {
+                            related_operations: vec![Some(NullableOperationIdentifier {
                                 index: 0,
                                 network_index: None,
                             })],
@@ -683,7 +683,7 @@ fn test_operations_validations() {
                 payload: OperationValidationsTest {
                     operations: vec![
                         Some(NullableOperation {
-                            operation_identifier: Some(OperationIdentifier {
+                            operation_identifier: Some(NullableOperationIdentifier {
                                 index: 0,
                                 network_index: None,
                             }),
@@ -694,7 +694,7 @@ fn test_operations_validations() {
                             ..Default::default()
                         }),
                         Some(NullableOperation {
-                            operation_identifier: Some(OperationIdentifier {
+                            operation_identifier: Some(NullableOperationIdentifier {
                                 index: 1,
                                 network_index: None,
                             }),
@@ -713,7 +713,7 @@ fn test_operations_validations() {
                             ..Default::default()
                         }),
                         Some(NullableOperation {
-                            operation_identifier: Some(OperationIdentifier {
+                            operation_identifier: Some(NullableOperationIdentifier {
                                 index: 2,
                                 network_index: None,
                             }),
@@ -736,7 +736,7 @@ fn test_operations_validations() {
                 payload: OperationValidationsTest {
                     operations: vec![
                         Some(NullableOperation {
-                            operation_identifier: Some(OperationIdentifier {
+                            operation_identifier: Some(NullableOperationIdentifier {
                                 index: 0,
                                 network_index: None,
                             }),
@@ -747,7 +747,7 @@ fn test_operations_validations() {
                             ..Default::default()
                         }),
                         Some(NullableOperation {
-                            operation_identifier: Some(OperationIdentifier {
+                            operation_identifier: Some(NullableOperationIdentifier {
                                 index: 1,
                                 network_index: None,
                             }),
@@ -766,7 +766,7 @@ fn test_operations_validations() {
                             ..Default::default()
                         }),
                         Some(NullableOperation {
-                            operation_identifier: Some(OperationIdentifier {
+                            operation_identifier: Some(NullableOperationIdentifier {
                                 index: 2,
                                 network_index: None,
                             }),
@@ -793,7 +793,7 @@ fn test_operations_validations() {
 #[derive(Default)]
 struct OperationTest {
     operation: Option<NullableOperation>,
-    index: i64,
+    index: isize,
     successful: bool,
     construction: bool,
 }
@@ -819,7 +819,7 @@ fn test_operation() {
             name: "valid operation",
             payload: OperationTest {
                 operation: Some(NullableOperation {
-                    operation_identifier: Some(OperationIdentifier {
+                    operation_identifier: Some(NullableOperationIdentifier {
                         index: 1,
                         network_index: None,
                     }),
@@ -839,7 +839,7 @@ fn test_operation() {
             name: "valid operation no account",
             payload: OperationTest {
                 operation: Some(NullableOperation {
-                    operation_identifier: Some(OperationIdentifier {
+                    operation_identifier: Some(NullableOperationIdentifier {
                         index: 1,
                         network_index: None,
                     }),
@@ -867,7 +867,7 @@ fn test_operation() {
             name: "invalid operation no account",
             payload: OperationTest {
                 operation: Some(NullableOperation {
-                    operation_identifier: Some(OperationIdentifier {
+                    operation_identifier: Some(NullableOperationIdentifier {
                         index: 1,
                         network_index: None,
                     }),
@@ -886,7 +886,7 @@ fn test_operation() {
             name: "invalid operation empty account",
             payload: OperationTest {
                 operation: Some(NullableOperation {
-                    operation_identifier: Some(OperationIdentifier {
+                    operation_identifier: Some(NullableOperationIdentifier {
                         index: 1,
                         network_index: None,
                     }),
@@ -906,7 +906,7 @@ fn test_operation() {
             name: "invalid operation invalid index",
             payload: OperationTest {
                 operation: Some(NullableOperation {
-                    operation_identifier: Some(OperationIdentifier {
+                    operation_identifier: Some(NullableOperationIdentifier {
                         index: 1,
                         network_index: None,
                     }),
@@ -924,7 +924,7 @@ fn test_operation() {
             name: "invalid operation invalid type",
             payload: OperationTest {
                 operation: Some(NullableOperation {
-                    operation_identifier: Some(OperationIdentifier {
+                    operation_identifier: Some(NullableOperationIdentifier {
                         index: 1,
                         network_index: None,
                     }),
@@ -942,7 +942,7 @@ fn test_operation() {
             name: "unsuccessful operation",
             payload: OperationTest {
                 operation: Some(NullableOperation {
-                    operation_identifier: Some(OperationIdentifier {
+                    operation_identifier: Some(NullableOperationIdentifier {
                         index: 1,
                         network_index: None,
                     }),
@@ -960,7 +960,7 @@ fn test_operation() {
             name: "invalid operation invalid status",
             payload: OperationTest {
                 operation: Some(NullableOperation {
-                    operation_identifier: Some(OperationIdentifier {
+                    operation_identifier: Some(NullableOperationIdentifier {
                         index: 1,
                         network_index: None,
                     }),
@@ -978,7 +978,7 @@ fn test_operation() {
             name: "valid construction operation",
             payload: OperationTest {
                 operation: Some(NullableOperation {
-                    operation_identifier: Some(OperationIdentifier {
+                    operation_identifier: Some(NullableOperationIdentifier {
                         index: 1,
                         network_index: None,
                     }),
@@ -997,7 +997,7 @@ fn test_operation() {
             name: "valid construction operation (empty status)",
             payload: OperationTest {
                 operation: Some(NullableOperation {
-                    operation_identifier: Some(OperationIdentifier {
+                    operation_identifier: Some(NullableOperationIdentifier {
                         index: 1,
                         network_index: None,
                     }),
@@ -1017,7 +1017,7 @@ fn test_operation() {
             name: "invalid construction operation",
             payload: OperationTest {
                 operation: Some(NullableOperation {
-                    operation_identifier: Some(OperationIdentifier {
+                    operation_identifier: Some(NullableOperationIdentifier {
                         index: 1,
                         network_index: None,
                     }),
@@ -1042,12 +1042,12 @@ fn test_operation() {
             sub_network_identifier: None,
         }),
         Some(NullableNetworkStatusResponse {
-            current_block_identifier: Some(BlockIdentifier {
+            current_block_identifier: Some(NullableBlockIdentifier {
                 index: 100,
                 hash: "block 100".into(),
             }),
             current_block_timestamp: MIN_UNIX_EPOCH + 1,
-            genesis_block_identifier: Some(BlockIdentifier {
+            genesis_block_identifier: Some(NullableBlockIdentifier {
                 index: 0,
                 hash: "block 0".into(),
             }),
@@ -1125,22 +1125,22 @@ fn test_operation() {
 
 #[derive(Default)]
 struct BlockTestExtras {
-    genesis_index: i64,
-    start_index: Option<i64>,
+    genesis_index: isize,
+    start_index: Option<isize>,
     validation_file_path: Option<PathBuf>,
 }
 
 #[test]
 fn test_block() {
-    let genesis_ident = BlockIdentifier {
+    let genesis_ident = NullableBlockIdentifier {
         hash: "gen".into(),
         index: 0,
     };
-    let valid_block_ident = BlockIdentifier {
+    let valid_block_ident = NullableBlockIdentifier {
         hash: "blah".into(),
         index: 100,
     };
-    let valid_parent_block_ident = BlockIdentifier {
+    let valid_parent_block_ident = NullableBlockIdentifier {
         hash: "blah parent".into(),
         index: 99,
     };
@@ -1163,7 +1163,7 @@ fn test_block() {
         }),
         operations: vec![
             Some(NullableOperation {
-                operation_identifier: Some(OperationIdentifier {
+                operation_identifier: Some(NullableOperationIdentifier {
                     index: 0,
                     network_index: None,
                 }),
@@ -1174,11 +1174,11 @@ fn test_block() {
                 ..Default::default()
             }),
             Some(NullableOperation {
-                operation_identifier: Some(OperationIdentifier {
+                operation_identifier: Some(NullableOperationIdentifier {
                     index: 1,
                     network_index: None,
                 }),
-                related_operations: vec![Some(OperationIdentifier {
+                related_operations: vec![Some(NullableOperationIdentifier {
                     index: 0,
                     network_index: None,
                 })],
@@ -1207,11 +1207,11 @@ fn test_block() {
             hash: "blah".into(),
         }),
         operations: vec![Some(NullableOperation {
-            operation_identifier: Some(OperationIdentifier {
+            operation_identifier: Some(NullableOperationIdentifier {
                 index: 0,
                 network_index: None,
             }),
-            related_operations: vec![Some(OperationIdentifier {
+            related_operations: vec![Some(NullableOperationIdentifier {
                 index: 0,
                 network_index: None,
             })],
@@ -1229,11 +1229,11 @@ fn test_block() {
         }),
         operations: vec![
             Some(NullableOperation {
-                operation_identifier: Some(OperationIdentifier {
+                operation_identifier: Some(NullableOperationIdentifier {
                     index: 1,
                     network_index: None,
                 }),
-                related_operations: vec![Some(OperationIdentifier {
+                related_operations: vec![Some(NullableOperationIdentifier {
                     index: 0,
                     network_index: None,
                 })],
@@ -1244,7 +1244,7 @@ fn test_block() {
                 ..Default::default()
             }),
             Some(NullableOperation {
-                operation_identifier: Some(OperationIdentifier {
+                operation_identifier: Some(NullableOperationIdentifier {
                     index: 0,
                     network_index: None,
                 }),
@@ -1263,11 +1263,11 @@ fn test_block() {
         }),
         operations: vec![
             Some(NullableOperation {
-                operation_identifier: Some(OperationIdentifier {
+                operation_identifier: Some(NullableOperationIdentifier {
                     index: 0,
                     network_index: None,
                 }),
-                related_operations: vec![Some(OperationIdentifier {
+                related_operations: vec![Some(NullableOperationIdentifier {
                     index: 1,
                     network_index: None,
                 })],
@@ -1278,11 +1278,11 @@ fn test_block() {
                 ..Default::default()
             }),
             Some(NullableOperation {
-                operation_identifier: Some(OperationIdentifier {
+                operation_identifier: Some(NullableOperationIdentifier {
                     index: 1,
                     network_index: None,
                 }),
-                related_operations: vec![Some(OperationIdentifier {
+                related_operations: vec![Some(NullableOperationIdentifier {
                     index: 0,
                     network_index: None,
                 })],
@@ -1301,7 +1301,7 @@ fn test_block() {
         }),
         operations: vec![
             Some(NullableOperation {
-                operation_identifier: Some(OperationIdentifier {
+                operation_identifier: Some(NullableOperationIdentifier {
                     index: 0,
                     network_index: None,
                 }),
@@ -1312,16 +1312,16 @@ fn test_block() {
                 ..Default::default()
             }),
             Some(NullableOperation {
-                operation_identifier: Some(OperationIdentifier {
+                operation_identifier: Some(NullableOperationIdentifier {
                     index: 1,
                     network_index: None,
                 }),
                 related_operations: vec![
-                    Some(OperationIdentifier {
+                    Some(NullableOperationIdentifier {
                         index: 0,
                         network_index: None,
                     }),
-                    Some(OperationIdentifier {
+                    Some(NullableOperationIdentifier {
                         index: 0,
                         network_index: None,
                     }),
@@ -1341,7 +1341,7 @@ fn test_block() {
         }),
         operations: vec![
             Some(NullableOperation {
-                operation_identifier: Some(OperationIdentifier {
+                operation_identifier: Some(NullableOperationIdentifier {
                     index: 0,
                     network_index: None,
                 }),
@@ -1352,7 +1352,7 @@ fn test_block() {
                 ..Default::default()
             }),
             Some(NullableOperation {
-                operation_identifier: Some(OperationIdentifier {
+                operation_identifier: Some(NullableOperationIdentifier {
                     index: 1,
                     network_index: None,
                 }),
@@ -1363,7 +1363,7 @@ fn test_block() {
                 ..Default::default()
             }),
             Some(NullableOperation {
-                operation_identifier: Some(OperationIdentifier {
+                operation_identifier: Some(NullableOperationIdentifier {
                     index: 2,
                     network_index: None,
                 }),
@@ -1382,7 +1382,7 @@ fn test_block() {
         }),
         operations: vec![
             Some(NullableOperation {
-                operation_identifier: Some(OperationIdentifier {
+                operation_identifier: Some(NullableOperationIdentifier {
                     index: 0,
                     network_index: None,
                 }),
@@ -1393,11 +1393,11 @@ fn test_block() {
                 ..Default::default()
             }),
             Some(NullableOperation {
-                operation_identifier: Some(OperationIdentifier {
+                operation_identifier: Some(NullableOperationIdentifier {
                     index: 1,
                     network_index: None,
                 }),
-                related_operations: vec![Some(OperationIdentifier {
+                related_operations: vec![Some(NullableOperationIdentifier {
                     index: 0,
                     network_index: None,
                 })],
@@ -1427,7 +1427,7 @@ fn test_block() {
         }),
         operations: vec![
             Some(NullableOperation {
-                operation_identifier: Some(OperationIdentifier {
+                operation_identifier: Some(NullableOperationIdentifier {
                     index: 0,
                     network_index: None,
                 }),
@@ -1438,11 +1438,11 @@ fn test_block() {
                 ..Default::default()
             }),
             Some(NullableOperation {
-                operation_identifier: Some(OperationIdentifier {
+                operation_identifier: Some(NullableOperationIdentifier {
                     index: 1,
                     network_index: None,
                 }),
-                related_operations: vec![Some(OperationIdentifier {
+                related_operations: vec![Some(NullableOperationIdentifier {
                     index: 0,
                     network_index: None,
                 })],
@@ -1488,12 +1488,12 @@ fn test_block() {
                 sub_network_identifier: None,
             }),
             Some(NullableNetworkStatusResponse {
-                current_block_identifier: Some(BlockIdentifier {
+                current_block_identifier: Some(NullableBlockIdentifier {
                     index: 100,
                     hash: "block 100".into(),
                 }),
                 current_block_timestamp: MIN_UNIX_EPOCH + 1,
-                genesis_block_identifier: Some(BlockIdentifier {
+                genesis_block_identifier: Some(NullableBlockIdentifier {
                     index: extras.genesis_index,
                     hash: format!("block {}", extras.genesis_index),
                 }),
@@ -1744,7 +1744,7 @@ fn test_block() {
                 caller: asserter(Default::default()),
                 payload: Some(NullableBlock {
                     block_identifier: Some(valid_block_ident.clone()),
-                    parent_block_identifier: Some(BlockIdentifier {
+                    parent_block_identifier: Some(NullableBlockIdentifier {
                         index: valid_block_ident.index,
                         hash: valid_parent_block_ident.hash.clone(),
                     }),
@@ -1761,7 +1761,7 @@ fn test_block() {
                 caller: asserter(Default::default()),
                 payload: Some(NullableBlock {
                     block_identifier: Some(valid_block_ident.clone()),
-                    parent_block_identifier: Some(BlockIdentifier {
+                    parent_block_identifier: Some(NullableBlockIdentifier {
                         index: valid_parent_block_ident.index,
                         hash: valid_block_ident.hash.clone(),
                     }),

--- a/crates/mentat-asserter/src/coin.rs
+++ b/crates/mentat-asserter/src/coin.rs
@@ -3,7 +3,7 @@
 use super::*;
 
 /// `coin` returns an error if the provided [`Coin`] is invalid.
-pub fn coin(coin: Option<&NullableCoin>) -> AssertResult<()> {
+pub fn coin(coin: Option<&UncheckedCoin>) -> AssertResult<()> {
     let coin = coin.ok_or(CoinError::IsNil)?;
     coin_identifier(coin.coin_identifier.as_ref())
         .map_err(|e| format!("{e}: coin identifier is invalid"))?;
@@ -15,7 +15,7 @@ pub fn coin(coin: Option<&NullableCoin>) -> AssertResult<()> {
 /// [`Coin`] is invalid. If there are any
 /// duplicate identifiers, this function
 /// will also return an error.
-pub fn coins(coins: &[Option<NullableCoin>]) -> AssertResult<()> {
+pub fn coins(coins: &[Option<UncheckedCoin>]) -> AssertResult<()> {
     let mut ids = IndexSet::new();
     for c in coins {
         coin(c.as_ref()).map_err(|err| format!("{err}: coin is invalid"))?;
@@ -44,7 +44,7 @@ pub fn coin_identifier(coin_identifier: Option<&CoinIdentifier>) -> AssertResult
 
 /// `coin_change` returns an error if the provided [`CoinChange`]
 /// is invalid.
-pub fn coin_change(change: Option<&NullableCoinChange>) -> AssertResult<()> {
+pub fn coin_change(change: Option<&UncheckedCoinChange>) -> AssertResult<()> {
     let change = change.ok_or(CoinError::ChangeIsNil)?;
 
     coin_identifier(change.coin_identifier.as_ref())
@@ -55,7 +55,7 @@ pub fn coin_change(change: Option<&NullableCoinChange>) -> AssertResult<()> {
 
 /// coin_action returns an error if the provided [`CoinAction`]
 /// is invalid.
-pub fn coin_action(act: &NullableCoinAction) -> AssertResult<()> {
+pub fn coin_action(act: &UncheckedCoinAction) -> AssertResult<()> {
     if !act.valid() {
         Err(AsserterError::from(format!(
             "{}: {}",

--- a/crates/mentat-asserter/src/coin_test.rs
+++ b/crates/mentat-asserter/src/coin_test.rs
@@ -2,9 +2,9 @@ use super::*;
 
 #[test]
 fn test_coin() {
-    let valid_amount = NullableAmount {
+    let valid_amount = UncheckedAmount {
         value: "1000".to_string(),
-        currency: Some(NullableCurrency {
+        currency: Some(UncheckedCurrency {
             symbol: "BTC".to_string(),
             decimals: 8,
             metadata: Default::default(),
@@ -15,7 +15,7 @@ fn test_coin() {
     let tests = vec![
         TestCase {
             name: "valid coin",
-            payload: Some(NullableCoin {
+            payload: Some(UncheckedCoin {
                 coin_identifier: Some(CoinIdentifier {
                     identifier: "coin1".to_string(),
                 }),
@@ -30,7 +30,7 @@ fn test_coin() {
         },
         TestCase {
             name: "invalid identifier",
-            payload: Some(NullableCoin {
+            payload: Some(UncheckedCoin {
                 coin_identifier: Some(CoinIdentifier {
                     identifier: String::new(),
                 }),
@@ -42,11 +42,11 @@ fn test_coin() {
         },
         TestCase {
             name: "invalid amount",
-            payload: Some(NullableCoin {
+            payload: Some(UncheckedCoin {
                 coin_identifier: Some(CoinIdentifier {
                     identifier: "coin1".to_string(),
                 }),
-                amount: Some(NullableAmount {
+                amount: Some(UncheckedAmount {
                     value: "100".to_string(),
                     currency: None,
                     metadata: Default::default(),
@@ -56,7 +56,7 @@ fn test_coin() {
         },
         TestCase {
             name: "nil amount",
-            payload: Some(NullableCoin {
+            payload: Some(UncheckedCoin {
                 coin_identifier: Some(CoinIdentifier {
                     identifier: "coin1".to_string(),
                 }),
@@ -71,9 +71,9 @@ fn test_coin() {
 
 #[test]
 fn test_coins() {
-    let valid_amount = NullableAmount {
+    let valid_amount = UncheckedAmount {
         value: "1000".to_string(),
-        currency: Some(NullableCurrency {
+        currency: Some(UncheckedCurrency {
             symbol: "BTC".to_string(),
             decimals: 8,
             metadata: Default::default(),
@@ -85,13 +85,13 @@ fn test_coins() {
         TestCase {
             name: "valid coins",
             payload: vec![
-                Some(NullableCoin {
+                Some(UncheckedCoin {
                     coin_identifier: Some(CoinIdentifier {
                         identifier: "coin1".to_string(),
                     }),
                     amount: Some(valid_amount.clone()),
                 }),
-                Some(NullableCoin {
+                Some(UncheckedCoin {
                     coin_identifier: Some(CoinIdentifier {
                         identifier: "coin2".to_string(),
                     }),
@@ -108,13 +108,13 @@ fn test_coins() {
         TestCase {
             name: "duplicate coins",
             payload: vec![
-                Some(NullableCoin {
+                Some(UncheckedCoin {
                     coin_identifier: Some(CoinIdentifier {
                         identifier: "coin1".to_string(),
                     }),
                     amount: Some(valid_amount.clone()),
                 }),
-                Some(NullableCoin {
+                Some(UncheckedCoin {
                     coin_identifier: Some(CoinIdentifier {
                         identifier: "coin1".to_string(),
                     }),
@@ -133,11 +133,11 @@ fn test_coin_change() {
     let tests = vec![
         TestCase {
             name: "valid change",
-            payload: Some(NullableCoinChange {
+            payload: Some(UncheckedCoinChange {
                 coin_identifier: Some(CoinIdentifier {
                     identifier: "coin1".to_string(),
                 }),
-                coin_action: NullableCoinAction::COIN_CREATED.into(),
+                coin_action: UncheckedCoinAction::COIN_CREATED.into(),
             }),
             criteria: None,
         },
@@ -148,17 +148,17 @@ fn test_coin_change() {
         },
         TestCase {
             name: "invalid identifier",
-            payload: Some(NullableCoinChange {
+            payload: Some(UncheckedCoinChange {
                 coin_identifier: Some(CoinIdentifier {
                     identifier: String::new(),
                 }),
-                coin_action: NullableCoinAction::COIN_CREATED.into(),
+                coin_action: UncheckedCoinAction::COIN_CREATED.into(),
             }),
             criteria: Some(CoinError::IdentifierNotSet.into()),
         },
         TestCase {
             name: "invalid coin action",
-            payload: Some(NullableCoinChange {
+            payload: Some(UncheckedCoinChange {
                 coin_identifier: Some(CoinIdentifier {
                     identifier: "coin1".to_string(),
                 }),

--- a/crates/mentat-asserter/src/construction.rs
+++ b/crates/mentat-asserter/src/construction.rs
@@ -4,7 +4,7 @@ use super::*;
 
 /// the request public keys are not valid AccountIdentifiers.
 pub fn construction_preprocess_response(
-    resp: Option<&NullableConstructionPreprocessResponse>,
+    resp: Option<&UncheckedConstructionPreprocessResponse>,
 ) -> AssertResult<()> {
     let resp = resp.ok_or(ConstructionError::ConstructionPreprocessResponseIsNil)?;
 
@@ -18,7 +18,7 @@ pub fn construction_preprocess_response(
 /// `construction_metadata_response` returns an error if
 /// the metadata is not a JSON object.
 pub fn construction_metadata_response(
-    resp: Option<&NullableConstructionMetadataResponse>,
+    resp: Option<&UncheckedConstructionMetadataResponse>,
 ) -> AssertResult<()> {
     let resp = resp.ok_or(ConstructionError::ConstructionMetadataResponseIsNil)?;
 
@@ -36,7 +36,7 @@ pub fn construction_metadata_response(
 /// the [`TransactionIdentifier`] in the response is not
 /// valid.
 pub fn transaction_identifier_response(
-    response: Option<&NullableTransactionIdentifierResponse>,
+    response: Option<&UncheckedTransactionIdentifierResponse>,
 ) -> AssertResult<()> {
     let response = response.ok_or(ConstructionError::TxIdentifierResponseIsNil)?;
     transaction_identifier(response.transaction_identifier.as_ref())
@@ -46,7 +46,7 @@ pub fn transaction_identifier_response(
 /// a [`ConstructionCombineResponse`] does
 /// not have a populated [`SignedTransaction`].
 pub fn construction_combine_response(
-    response: Option<&NullableConstructionCombineResponse>,
+    response: Option<&UncheckedConstructionCombineResponse>,
 ) -> AssertResult<()> {
     let response = response.ok_or(ConstructionError::ConstructionCombineResponseIsNil)?;
     if response.signed_transaction.is_empty() {
@@ -60,7 +60,7 @@ pub fn construction_combine_response(
 /// a [`ConstructionDeriveResponse`] does
 /// not have a populated Address.
 pub fn construction_derive_response(
-    resp: Option<&NullableConstructionDeriveResponse>,
+    resp: Option<&UncheckedConstructionDeriveResponse>,
 ) -> AssertResult<()> {
     let resp = resp.ok_or(ConstructionError::ConstructionDeriveResponseIsNil)?;
 
@@ -81,7 +81,7 @@ impl Asserter {
     /// if the signers is empty.
     pub fn construction_parse_response(
         &self,
-        resp: Option<&NullableConstructionParseResponse>,
+        resp: Option<&UncheckedConstructionParseResponse>,
         signed: bool,
     ) -> AssertResult<()> {
         self.response
@@ -135,7 +135,7 @@ impl Asserter {
 /// not have an UnsignedTransaction or has no
 /// valid [`SigningPayload`].
 pub fn construction_payloads_response(
-    resp: Option<&NullableConstructionPayloadsResponse>,
+    resp: Option<&UncheckedConstructionPayloadsResponse>,
 ) -> AssertResult<()> {
     let resp = resp.ok_or(ConstructionError::ConstructionPayloadsResponseIsNil)?;
 
@@ -161,7 +161,7 @@ pub fn construction_payloads_response(
 /// `public_key` returns an error if
 /// the [PublicKey] is nil, is not
 /// valid hex, or has an undefined CurveType.
-pub fn public_key(key: Option<&NullablePublicKey>) -> AssertResult<()> {
+pub fn public_key(key: Option<&UncheckedPublicKey>) -> AssertResult<()> {
     let key = key.ok_or(ConstructionError::PublicKeyIsNil)?;
 
     if key.bytes.is_empty() {
@@ -180,7 +180,7 @@ pub fn public_key(key: Option<&NullablePublicKey>) -> AssertResult<()> {
 
 /// `curve_type` returns an error if
 /// the curve is not a valid [CurveType].
-pub fn curve_type(curve: &NullableCurveType) -> AssertResult<()> {
+pub fn curve_type(curve: &UncheckedCurveType) -> AssertResult<()> {
     if !curve.valid() {
         Err(format!(
             "{}: {}",
@@ -196,7 +196,7 @@ pub fn curve_type(curve: &NullableCurveType) -> AssertResult<()> {
 /// if a [SigningPayload] is nil,
 /// has an empty address, has invalid hex,
 /// or has an invalid [SignatureType] (if populated).
-pub fn signing_payload(payload: Option<&NullableSigningPayload>) -> AssertResult<()> {
+pub fn signing_payload(payload: Option<&UncheckedSigningPayload>) -> AssertResult<()> {
     let payload = payload.ok_or(ConstructionError::SigningPayloadIsNil)?;
 
     account_identifier(payload.account_identifier.as_ref())
@@ -223,7 +223,7 @@ pub fn signing_payload(payload: Option<&NullableSigningPayload>) -> AssertResult
 
 /// `signatures` returns an error if any
 /// [Signature] is invalid.
-pub fn signatures(signatures: &[Option<&NullableSignature>]) -> AssertResult<()> {
+pub fn signatures(signatures: &[Option<&UncheckedSignature>]) -> AssertResult<()> {
     if signatures.is_empty() {
         Err(ConstructionError::SignaturesEmpty)?;
     }
@@ -260,7 +260,7 @@ pub fn signatures(signatures: &[Option<&NullableSignature>]) -> AssertResult<()>
 
 /// signature_type returns an error if
 /// signature is not a valid [`SignatureType`].
-pub fn signature_type(st: &NullableSignatureType) -> AssertResult<()> {
+pub fn signature_type(st: &UncheckedSignatureType) -> AssertResult<()> {
     if !st.valid() {
         Err(AsserterError::from(format!(
             "{}: {}",

--- a/crates/mentat-asserter/src/construction_test.rs
+++ b/crates/mentat-asserter/src/construction_test.rs
@@ -189,7 +189,7 @@ fn test_construction_parse_response() {
                 payload: Some(NullableConstructionParseResponse {
                     operations: vec![
                         Some(NullableOperation {
-                            operation_identifier: Some(OperationIdentifier {
+                            operation_identifier: Some(NullableOperationIdentifier {
                                 index: 0,
                                 ..Default::default()
                             }),
@@ -199,11 +199,11 @@ fn test_construction_parse_response() {
                             ..Default::default()
                         }),
                         Some(NullableOperation {
-                            operation_identifier: Some(OperationIdentifier {
+                            operation_identifier: Some(NullableOperationIdentifier {
                                 index: 1,
                                 ..Default::default()
                             }),
-                            related_operations: vec![Some(OperationIdentifier {
+                            related_operations: vec![Some(NullableOperationIdentifier {
                                 index: 0,
                                 ..Default::default()
                             })],
@@ -227,7 +227,7 @@ fn test_construction_parse_response() {
                 payload: Some(NullableConstructionParseResponse {
                     operations: vec![
                         Some(NullableOperation {
-                            operation_identifier: Some(OperationIdentifier {
+                            operation_identifier: Some(NullableOperationIdentifier {
                                 index: 0,
                                 ..Default::default()
                             }),
@@ -237,11 +237,11 @@ fn test_construction_parse_response() {
                             ..Default::default()
                         }),
                         Some(NullableOperation {
-                            operation_identifier: Some(OperationIdentifier {
+                            operation_identifier: Some(NullableOperationIdentifier {
                                 index: 1,
                                 ..Default::default()
                             }),
-                            related_operations: vec![Some(OperationIdentifier {
+                            related_operations: vec![Some(NullableOperationIdentifier {
                                 index: 0,
                                 ..Default::default()
                             })],
@@ -284,7 +284,7 @@ fn test_construction_parse_response() {
             payload: Some(ConstructionParseResponseTest {
                 payload: Some(NullableConstructionParseResponse {
                     operations: vec![Some(NullableOperation {
-                        operation_identifier: Some(OperationIdentifier {
+                        operation_identifier: Some(NullableOperationIdentifier {
                             index: 1,
                             ..Default::default()
                         }),
@@ -307,7 +307,7 @@ fn test_construction_parse_response() {
                 payload: Some(NullableConstructionParseResponse {
                     operations: vec![
                         Some(NullableOperation {
-                            operation_identifier: Some(OperationIdentifier {
+                            operation_identifier: Some(NullableOperationIdentifier {
                                 index: 0,
                                 ..Default::default()
                             }),
@@ -317,11 +317,11 @@ fn test_construction_parse_response() {
                             ..Default::default()
                         }),
                         Some(NullableOperation {
-                            operation_identifier: Some(OperationIdentifier {
+                            operation_identifier: Some(NullableOperationIdentifier {
                                 index: 1,
                                 ..Default::default()
                             }),
-                            related_operations: vec![Some(OperationIdentifier {
+                            related_operations: vec![Some(NullableOperationIdentifier {
                                 index: 0,
                                 ..Default::default()
                             })],
@@ -346,7 +346,7 @@ fn test_construction_parse_response() {
                 payload: Some(NullableConstructionParseResponse {
                     operations: vec![
                         Some(NullableOperation {
-                            operation_identifier: Some(OperationIdentifier {
+                            operation_identifier: Some(NullableOperationIdentifier {
                                 index: 0,
                                 ..Default::default()
                             }),
@@ -356,11 +356,11 @@ fn test_construction_parse_response() {
                             ..Default::default()
                         }),
                         Some(NullableOperation {
-                            operation_identifier: Some(OperationIdentifier {
+                            operation_identifier: Some(NullableOperationIdentifier {
                                 index: 1,
                                 ..Default::default()
                             }),
-                            related_operations: vec![Some(OperationIdentifier {
+                            related_operations: vec![Some(NullableOperationIdentifier {
                                 index: 0,
                                 ..Default::default()
                             })],
@@ -384,7 +384,7 @@ fn test_construction_parse_response() {
                 payload: Some(NullableConstructionParseResponse {
                     operations: vec![
                         Some(NullableOperation {
-                            operation_identifier: Some(OperationIdentifier {
+                            operation_identifier: Some(NullableOperationIdentifier {
                                 index: 0,
                                 ..Default::default()
                             }),
@@ -394,11 +394,11 @@ fn test_construction_parse_response() {
                             ..Default::default()
                         }),
                         Some(NullableOperation {
-                            operation_identifier: Some(OperationIdentifier {
+                            operation_identifier: Some(NullableOperationIdentifier {
                                 index: 1,
                                 ..Default::default()
                             }),
-                            related_operations: vec![Some(OperationIdentifier {
+                            related_operations: vec![Some(NullableOperationIdentifier {
                                 index: 0,
                                 ..Default::default()
                             })],
@@ -424,7 +424,7 @@ fn test_construction_parse_response() {
                 payload: Some(NullableConstructionParseResponse {
                     operations: vec![
                         Some(NullableOperation {
-                            operation_identifier: Some(OperationIdentifier {
+                            operation_identifier: Some(NullableOperationIdentifier {
                                 index: 0,
                                 ..Default::default()
                             }),
@@ -434,11 +434,11 @@ fn test_construction_parse_response() {
                             ..Default::default()
                         }),
                         Some(NullableOperation {
-                            operation_identifier: Some(OperationIdentifier {
+                            operation_identifier: Some(NullableOperationIdentifier {
                                 index: 1,
                                 ..Default::default()
                             }),
-                            related_operations: vec![Some(OperationIdentifier {
+                            related_operations: vec![Some(NullableOperationIdentifier {
                                 index: 0,
                                 ..Default::default()
                             })],
@@ -464,11 +464,11 @@ fn test_construction_parse_response() {
             ..Default::default()
         }),
         Some(NullableNetworkStatusResponse {
-            current_block_identifier: Some(BlockIdentifier {
+            current_block_identifier: Some(NullableBlockIdentifier {
                 index: 100,
                 hash: "block 100".into(),
             }),
-            genesis_block_identifier: Some(BlockIdentifier {
+            genesis_block_identifier: Some(NullableBlockIdentifier {
                 index: 0,
                 hash: "block 0".into(),
             }),

--- a/crates/mentat-asserter/src/construction_test.rs
+++ b/crates/mentat-asserter/src/construction_test.rs
@@ -5,14 +5,14 @@ fn test_construction_preprocess_response() {
     let tests = vec![
         TestCase {
             name: "valid response",
-            payload: Some(NullableConstructionPreprocessResponse {
+            payload: Some(UncheckedConstructionPreprocessResponse {
                 ..Default::default()
             }),
             criteria: None,
         },
         TestCase {
             name: "valid response with accounts",
-            payload: Some(NullableConstructionPreprocessResponse {
+            payload: Some(UncheckedConstructionPreprocessResponse {
                 required_public_keys: vec![Some(AccountIdentifier {
                     address: "hello".into(),
                     ..Default::default()
@@ -23,7 +23,7 @@ fn test_construction_preprocess_response() {
         },
         TestCase {
             name: "invalid response with accounts",
-            payload: Some(NullableConstructionPreprocessResponse {
+            payload: Some(UncheckedConstructionPreprocessResponse {
                 required_public_keys: vec![Some(AccountIdentifier {
                     address: "".into(),
                     ..Default::default()
@@ -47,7 +47,7 @@ fn test_construction_metadata_response() {
     let tests = vec![
         TestCase {
             name: "valid response",
-            payload: Some(NullableConstructionMetadataResponse {
+            payload: Some(UncheckedConstructionMetadataResponse {
                 metadata: Some(Default::default()),
                 ..Default::default()
             }),
@@ -55,7 +55,7 @@ fn test_construction_metadata_response() {
         },
         TestCase {
             name: "with suggested fee",
-            payload: Some(NullableConstructionMetadataResponse {
+            payload: Some(UncheckedConstructionMetadataResponse {
                 metadata: Some(Default::default()),
                 suggested_fee: vec![valid_amount()],
             }),
@@ -63,7 +63,7 @@ fn test_construction_metadata_response() {
         },
         TestCase {
             name: "with duplicate suggested fee",
-            payload: Some(NullableConstructionMetadataResponse {
+            payload: Some(UncheckedConstructionMetadataResponse {
                 metadata: Some(Default::default()),
                 suggested_fee: vec![valid_amount(), valid_amount()],
             }),
@@ -95,7 +95,7 @@ fn test_transaction_identifier_response() {
     let tests = vec![
         TestCase {
             name: "valid response",
-            payload: Some(NullableTransactionIdentifierResponse {
+            payload: Some(UncheckedTransactionIdentifierResponse {
                 transaction_identifier: Some(TransactionIdentifier { hash: "tx1".into() }),
                 ..Default::default()
             }),
@@ -121,7 +121,7 @@ fn test_construction_combine_response() {
     let tests = vec![
         TestCase {
             name: "valid response",
-            payload: Some(NullableConstructionCombineResponse {
+            payload: Some(UncheckedConstructionCombineResponse {
                 signed_transaction: "signed tx".into(),
             }),
             criteria: None,
@@ -146,7 +146,7 @@ fn test_construction_derive_response() {
     let tests = vec![
         TestCase {
             name: "valid response",
-            payload: Some(NullableConstructionDeriveResponse {
+            payload: Some(UncheckedConstructionDeriveResponse {
                 account_identifier: Some(AccountIdentifier {
                     address: "addr".into(),
                     metadata: [("name".into(), "hello".into())].into(),
@@ -163,7 +163,7 @@ fn test_construction_derive_response() {
         },
         TestCase {
             name: "empty address",
-            payload: Some(NullableConstructionDeriveResponse {
+            payload: Some(UncheckedConstructionDeriveResponse {
                 metadata: [("name".into(), "hello".into())].into(),
                 ..Default::default()
             }),
@@ -176,7 +176,7 @@ fn test_construction_derive_response() {
 
 #[derive(Default)]
 struct ConstructionParseResponseTest {
-    payload: Option<NullableConstructionParseResponse>,
+    payload: Option<UncheckedConstructionParseResponse>,
     signed: bool,
 }
 
@@ -186,10 +186,10 @@ fn test_construction_parse_response() {
         TestCase {
             name: "valid response",
             payload: Some(ConstructionParseResponseTest {
-                payload: Some(NullableConstructionParseResponse {
+                payload: Some(UncheckedConstructionParseResponse {
                     operations: vec![
-                        Some(NullableOperation {
-                            operation_identifier: Some(NullableOperationIdentifier {
+                        Some(UncheckedOperation {
+                            operation_identifier: Some(UncheckedOperationIdentifier {
                                 index: 0,
                                 ..Default::default()
                             }),
@@ -198,12 +198,12 @@ fn test_construction_parse_response() {
                             amount: valid_amount(),
                             ..Default::default()
                         }),
-                        Some(NullableOperation {
-                            operation_identifier: Some(NullableOperationIdentifier {
+                        Some(UncheckedOperation {
+                            operation_identifier: Some(UncheckedOperationIdentifier {
                                 index: 1,
                                 ..Default::default()
                             }),
-                            related_operations: vec![Some(NullableOperationIdentifier {
+                            related_operations: vec![Some(UncheckedOperationIdentifier {
                                 index: 0,
                                 ..Default::default()
                             })],
@@ -224,10 +224,10 @@ fn test_construction_parse_response() {
         TestCase {
             name: "duplicate signer",
             payload: Some(ConstructionParseResponseTest {
-                payload: Some(NullableConstructionParseResponse {
+                payload: Some(UncheckedConstructionParseResponse {
                     operations: vec![
-                        Some(NullableOperation {
-                            operation_identifier: Some(NullableOperationIdentifier {
+                        Some(UncheckedOperation {
+                            operation_identifier: Some(UncheckedOperationIdentifier {
                                 index: 0,
                                 ..Default::default()
                             }),
@@ -236,12 +236,12 @@ fn test_construction_parse_response() {
                             amount: valid_amount(),
                             ..Default::default()
                         }),
-                        Some(NullableOperation {
-                            operation_identifier: Some(NullableOperationIdentifier {
+                        Some(UncheckedOperation {
+                            operation_identifier: Some(UncheckedOperationIdentifier {
                                 index: 1,
                                 ..Default::default()
                             }),
-                            related_operations: vec![Some(NullableOperationIdentifier {
+                            related_operations: vec![Some(UncheckedOperationIdentifier {
                                 index: 0,
                                 ..Default::default()
                             })],
@@ -270,7 +270,7 @@ fn test_construction_parse_response() {
         TestCase {
             name: "no operations",
             payload: Some(ConstructionParseResponseTest {
-                payload: Some(NullableConstructionParseResponse {
+                payload: Some(UncheckedConstructionParseResponse {
                     account_identifier_signers: vec![valid_account()],
                     metadata: [("extra".into(), "stuff".into())].into(),
                     ..Default::default()
@@ -282,9 +282,9 @@ fn test_construction_parse_response() {
         TestCase {
             name: "invalid operation ordering",
             payload: Some(ConstructionParseResponseTest {
-                payload: Some(NullableConstructionParseResponse {
-                    operations: vec![Some(NullableOperation {
-                        operation_identifier: Some(NullableOperationIdentifier {
+                payload: Some(UncheckedConstructionParseResponse {
+                    operations: vec![Some(UncheckedOperation {
+                        operation_identifier: Some(UncheckedOperationIdentifier {
                             index: 1,
                             ..Default::default()
                         }),
@@ -304,10 +304,10 @@ fn test_construction_parse_response() {
         TestCase {
             name: "no signers",
             payload: Some(ConstructionParseResponseTest {
-                payload: Some(NullableConstructionParseResponse {
+                payload: Some(UncheckedConstructionParseResponse {
                     operations: vec![
-                        Some(NullableOperation {
-                            operation_identifier: Some(NullableOperationIdentifier {
+                        Some(UncheckedOperation {
+                            operation_identifier: Some(UncheckedOperationIdentifier {
                                 index: 0,
                                 ..Default::default()
                             }),
@@ -316,12 +316,12 @@ fn test_construction_parse_response() {
                             amount: valid_amount(),
                             ..Default::default()
                         }),
-                        Some(NullableOperation {
-                            operation_identifier: Some(NullableOperationIdentifier {
+                        Some(UncheckedOperation {
+                            operation_identifier: Some(UncheckedOperationIdentifier {
                                 index: 1,
                                 ..Default::default()
                             }),
-                            related_operations: vec![Some(NullableOperationIdentifier {
+                            related_operations: vec![Some(UncheckedOperationIdentifier {
                                 index: 0,
                                 ..Default::default()
                             })],
@@ -343,10 +343,10 @@ fn test_construction_parse_response() {
         TestCase {
             name: "empty account identifier signer",
             payload: Some(ConstructionParseResponseTest {
-                payload: Some(NullableConstructionParseResponse {
+                payload: Some(UncheckedConstructionParseResponse {
                     operations: vec![
-                        Some(NullableOperation {
-                            operation_identifier: Some(NullableOperationIdentifier {
+                        Some(UncheckedOperation {
+                            operation_identifier: Some(UncheckedOperationIdentifier {
                                 index: 0,
                                 ..Default::default()
                             }),
@@ -355,12 +355,12 @@ fn test_construction_parse_response() {
                             amount: valid_amount(),
                             ..Default::default()
                         }),
-                        Some(NullableOperation {
-                            operation_identifier: Some(NullableOperationIdentifier {
+                        Some(UncheckedOperation {
+                            operation_identifier: Some(UncheckedOperationIdentifier {
                                 index: 1,
                                 ..Default::default()
                             }),
-                            related_operations: vec![Some(NullableOperationIdentifier {
+                            related_operations: vec![Some(UncheckedOperationIdentifier {
                                 index: 0,
                                 ..Default::default()
                             })],
@@ -381,10 +381,10 @@ fn test_construction_parse_response() {
         TestCase {
             name: "invalid signer unsigned",
             payload: Some(ConstructionParseResponseTest {
-                payload: Some(NullableConstructionParseResponse {
+                payload: Some(UncheckedConstructionParseResponse {
                     operations: vec![
-                        Some(NullableOperation {
-                            operation_identifier: Some(NullableOperationIdentifier {
+                        Some(UncheckedOperation {
+                            operation_identifier: Some(UncheckedOperationIdentifier {
                                 index: 0,
                                 ..Default::default()
                             }),
@@ -393,12 +393,12 @@ fn test_construction_parse_response() {
                             amount: valid_amount(),
                             ..Default::default()
                         }),
-                        Some(NullableOperation {
-                            operation_identifier: Some(NullableOperationIdentifier {
+                        Some(UncheckedOperation {
+                            operation_identifier: Some(UncheckedOperationIdentifier {
                                 index: 1,
                                 ..Default::default()
                             }),
-                            related_operations: vec![Some(NullableOperationIdentifier {
+                            related_operations: vec![Some(UncheckedOperationIdentifier {
                                 index: 0,
                                 ..Default::default()
                             })],
@@ -421,10 +421,10 @@ fn test_construction_parse_response() {
         TestCase {
             name: "valid response unsigned",
             payload: Some(ConstructionParseResponseTest {
-                payload: Some(NullableConstructionParseResponse {
+                payload: Some(UncheckedConstructionParseResponse {
                     operations: vec![
-                        Some(NullableOperation {
-                            operation_identifier: Some(NullableOperationIdentifier {
+                        Some(UncheckedOperation {
+                            operation_identifier: Some(UncheckedOperationIdentifier {
                                 index: 0,
                                 ..Default::default()
                             }),
@@ -433,12 +433,12 @@ fn test_construction_parse_response() {
                             amount: valid_amount(),
                             ..Default::default()
                         }),
-                        Some(NullableOperation {
-                            operation_identifier: Some(NullableOperationIdentifier {
+                        Some(UncheckedOperation {
+                            operation_identifier: Some(UncheckedOperationIdentifier {
                                 index: 1,
                                 ..Default::default()
                             }),
-                            related_operations: vec![Some(NullableOperationIdentifier {
+                            related_operations: vec![Some(UncheckedOperationIdentifier {
                                 index: 0,
                                 ..Default::default()
                             })],
@@ -463,12 +463,12 @@ fn test_construction_parse_response() {
             network: "WORLD".into(),
             ..Default::default()
         }),
-        Some(NullableNetworkStatusResponse {
-            current_block_identifier: Some(NullableBlockIdentifier {
+        Some(UncheckedNetworkStatusResponse {
+            current_block_identifier: Some(UncheckedBlockIdentifier {
                 index: 100,
                 hash: "block 100".into(),
             }),
-            genesis_block_identifier: Some(NullableBlockIdentifier {
+            genesis_block_identifier: Some(UncheckedBlockIdentifier {
                 index: 0,
                 hash: "block 0".into(),
             }),
@@ -479,13 +479,13 @@ fn test_construction_parse_response() {
             })],
             ..Default::default()
         }),
-        Some(NullableNetworkOptionsResponse {
+        Some(UncheckedNetworkOptionsResponse {
             version: Some(Version {
                 rosetta_version: "1.4.0".into(),
                 node_version: "1.0".into(),
                 ..Default::default()
             }),
-            allow: Some(NullableAllow {
+            allow: Some(UncheckedAllow {
                 operation_statuses: vec![
                     Some(OperationStatus {
                         status: "SUCCESS".into(),
@@ -515,9 +515,9 @@ fn test_construction_payloads_response() {
     let tests = vec![
         TestCase {
             name: "valid response",
-            payload: Some(NullableConstructionPayloadsResponse {
+            payload: Some(UncheckedConstructionPayloadsResponse {
                 unsigned_transaction: "tx blob".into(),
-                payloads: vec![Some(NullableSigningPayload {
+                payloads: vec![Some(UncheckedSigningPayload {
                     account_identifier: Some(AccountIdentifier {
                         address: "hello".into(),
                         ..Default::default()
@@ -535,8 +535,8 @@ fn test_construction_payloads_response() {
         },
         TestCase {
             name: "empty unsigned transaction",
-            payload: Some(NullableConstructionPayloadsResponse {
-                payloads: vec![Some(NullableSigningPayload {
+            payload: Some(UncheckedConstructionPayloadsResponse {
+                payloads: vec![Some(UncheckedSigningPayload {
                     account_identifier: Some(AccountIdentifier {
                         address: "hello".into(),
                         ..Default::default()
@@ -550,7 +550,7 @@ fn test_construction_payloads_response() {
         },
         TestCase {
             name: "empty signing payloads",
-            payload: Some(NullableConstructionPayloadsResponse {
+            payload: Some(UncheckedConstructionPayloadsResponse {
                 unsigned_transaction: "tx blob".into(),
                 ..Default::default()
             }),
@@ -558,9 +558,9 @@ fn test_construction_payloads_response() {
         },
         TestCase {
             name: "invalid signing payload",
-            payload: Some(NullableConstructionPayloadsResponse {
+            payload: Some(UncheckedConstructionPayloadsResponse {
                 unsigned_transaction: "tx blob".into(),
-                payloads: vec![Some(NullableSigningPayload {
+                payloads: vec![Some(UncheckedSigningPayload {
                     bytes: "48656c6c6f20476f7068657221".into(),
                     ..Default::default()
                 })],
@@ -577,17 +577,17 @@ fn test_public_key() {
     let tests = vec![
         TestCase {
             name: "valid public key",
-            payload: Some(NullablePublicKey {
+            payload: Some(UncheckedPublicKey {
                 bytes: "blah".into(),
-                curve_type: NullableCurveType::SECP256K1.into(),
+                curve_type: UncheckedCurveType::SECP256K1.into(),
             }),
             criteria: None,
         },
         TestCase {
             name: "zero public key",
-            payload: Some(NullablePublicKey {
+            payload: Some(UncheckedPublicKey {
                 bytes: vec![0; 4],
-                curve_type: NullableCurveType::SECP256K1.into(),
+                curve_type: UncheckedCurveType::SECP256K1.into(),
             }),
             criteria: Some(ConstructionError::PublicKeyBytesZero.into()),
         },
@@ -598,15 +598,15 @@ fn test_public_key() {
         },
         TestCase {
             name: "invalid bytes",
-            payload: Some(NullablePublicKey {
-                curve_type: NullableCurveType::SECP256K1.into(),
+            payload: Some(UncheckedPublicKey {
+                curve_type: UncheckedCurveType::SECP256K1.into(),
                 ..Default::default()
             }),
             criteria: Some(ConstructionError::PublicKeyBytesEmpty.into()),
         },
         TestCase {
             name: "invalid curve",
-            payload: Some(NullablePublicKey {
+            payload: Some(UncheckedPublicKey {
                 bytes: "hello".into(),
                 curve_type: "test".into(),
             }),
@@ -622,7 +622,7 @@ fn test_signing_payload() {
     let tests = vec![
         TestCase {
             name: "valid signing payload",
-            payload: Some(NullableSigningPayload {
+            payload: Some(UncheckedSigningPayload {
                 account_identifier: Some(AccountIdentifier {
                     address: "hello".into(),
                     ..Default::default()
@@ -634,13 +634,13 @@ fn test_signing_payload() {
         },
         TestCase {
             name: "valid signing payload with signature type",
-            payload: Some(NullableSigningPayload {
+            payload: Some(UncheckedSigningPayload {
                 account_identifier: Some(AccountIdentifier {
                     address: "hello".into(),
                     ..Default::default()
                 }),
                 bytes: "blah".into(),
-                signature_type: NullableSignatureType::ED25519.into(),
+                signature_type: UncheckedSignatureType::ED25519.into(),
                 ..Default::default()
             }),
             criteria: None,
@@ -652,7 +652,7 @@ fn test_signing_payload() {
         },
         TestCase {
             name: "empty address",
-            payload: Some(NullableSigningPayload {
+            payload: Some(UncheckedSigningPayload {
                 bytes: "blah".into(),
                 ..Default::default()
             }),
@@ -660,7 +660,7 @@ fn test_signing_payload() {
         },
         TestCase {
             name: "zero signing payload",
-            payload: Some(NullableSigningPayload {
+            payload: Some(UncheckedSigningPayload {
                 account_identifier: Some(AccountIdentifier {
                     address: "hello".into(),
                     ..Default::default()
@@ -672,7 +672,7 @@ fn test_signing_payload() {
         },
         TestCase {
             name: "empty bytes",
-            payload: Some(NullableSigningPayload {
+            payload: Some(UncheckedSigningPayload {
                 account_identifier: Some(AccountIdentifier {
                     address: "hello".into(),
                     ..Default::default()
@@ -683,7 +683,7 @@ fn test_signing_payload() {
         },
         TestCase {
             name: "invalid signature",
-            payload: Some(NullableSigningPayload {
+            payload: Some(UncheckedSigningPayload {
                 account_identifier: Some(AccountIdentifier {
                     address: "hello".into(),
                     ..Default::default()
@@ -705,24 +705,24 @@ fn test_signatures() {
         TestCase {
             name: "valid signatures",
             payload: vec![
-                Some(NullableSignature {
-                    signing_payload: Some(NullableSigningPayload {
+                Some(UncheckedSignature {
+                    signing_payload: Some(UncheckedSigningPayload {
                         account_identifier: valid_account(),
                         bytes: "blah".into(),
                         ..Default::default()
                     }),
                     public_key: Some(valid_public_key()),
-                    signature_type: NullableSignatureType::ED25519.into(),
+                    signature_type: UncheckedSignatureType::ED25519.into(),
                     bytes: "hello".into(),
                 }),
-                Some(NullableSignature {
-                    signing_payload: Some(NullableSigningPayload {
+                Some(UncheckedSignature {
+                    signing_payload: Some(UncheckedSigningPayload {
                         account_identifier: valid_account(),
                         bytes: "blah".into(),
                         ..Default::default()
                     }),
                     public_key: Some(valid_public_key()),
-                    signature_type: NullableSignatureType::ECDSA_RECOVERY.into(),
+                    signature_type: UncheckedSignatureType::ECDSA_RECOVERY.into(),
                     bytes: "hello".into(),
                 }),
             ],
@@ -730,15 +730,15 @@ fn test_signatures() {
         },
         TestCase {
             name: "signature type match",
-            payload: vec![Some(NullableSignature {
-                signing_payload: Some(NullableSigningPayload {
+            payload: vec![Some(UncheckedSignature {
+                signing_payload: Some(UncheckedSigningPayload {
                     account_identifier: valid_account(),
                     bytes: "blah".into(),
-                    signature_type: NullableSignatureType::ED25519.into(),
+                    signature_type: UncheckedSignatureType::ED25519.into(),
                     ..Default::default()
                 }),
                 public_key: Some(valid_public_key()),
-                signature_type: NullableSignatureType::ED25519.into(),
+                signature_type: UncheckedSignatureType::ED25519.into(),
                 bytes: "hello".into(),
             })],
             criteria: None,
@@ -751,25 +751,25 @@ fn test_signatures() {
         TestCase {
             name: "empty signature",
             payload: vec![
-                Some(NullableSignature {
-                    signing_payload: Some(NullableSigningPayload {
+                Some(UncheckedSignature {
+                    signing_payload: Some(UncheckedSigningPayload {
                         account_identifier: valid_account(),
                         bytes: "blah".into(),
                         ..Default::default()
                     }),
                     public_key: Some(valid_public_key()),
-                    signature_type: NullableSignatureType::ECDSA_RECOVERY.into(),
+                    signature_type: UncheckedSignatureType::ECDSA_RECOVERY.into(),
                     bytes: "hello".into(),
                 }),
-                Some(NullableSignature {
-                    signing_payload: Some(NullableSigningPayload {
+                Some(UncheckedSignature {
+                    signing_payload: Some(UncheckedSigningPayload {
                         account_identifier: valid_account(),
                         bytes: "blah".into(),
-                        signature_type: NullableSignatureType::ED25519.into(),
+                        signature_type: UncheckedSignatureType::ED25519.into(),
                         ..Default::default()
                     }),
                     public_key: Some(valid_public_key()),
-                    signature_type: NullableSignatureType::ED25519.into(),
+                    signature_type: UncheckedSignatureType::ED25519.into(),
                     ..Default::default()
                 }),
             ],
@@ -777,30 +777,30 @@ fn test_signatures() {
         },
         TestCase {
             name: "signature zero bytes",
-            payload: vec![Some(NullableSignature {
-                signing_payload: Some(NullableSigningPayload {
+            payload: vec![Some(UncheckedSignature {
+                signing_payload: Some(UncheckedSigningPayload {
                     account_identifier: valid_account(),
                     bytes: "blah".into(),
-                    signature_type: NullableSignatureType::ED25519.into(),
+                    signature_type: UncheckedSignatureType::ED25519.into(),
                     ..Default::default()
                 }),
                 public_key: Some(valid_public_key()),
-                signature_type: NullableSignatureType::ED25519.into(),
+                signature_type: UncheckedSignatureType::ED25519.into(),
                 bytes: vec![0],
             })],
             criteria: Some(ConstructionError::SignatureBytesZero.into()),
         },
         TestCase {
             name: "signature type mismatch",
-            payload: vec![Some(NullableSignature {
-                signing_payload: Some(NullableSigningPayload {
+            payload: vec![Some(UncheckedSignature {
+                signing_payload: Some(UncheckedSigningPayload {
                     account_identifier: valid_account(),
                     bytes: "blah".into(),
-                    signature_type: NullableSignatureType::ECDSA_RECOVERY.into(),
+                    signature_type: UncheckedSignatureType::ECDSA_RECOVERY.into(),
                     ..Default::default()
                 }),
                 public_key: Some(valid_public_key()),
-                signature_type: NullableSignatureType::ED25519.into(),
+                signature_type: UncheckedSignatureType::ED25519.into(),
                 bytes: "hello".into(),
             })],
             criteria: Some(ConstructionError::SignaturesReturnedSigMismatch.into()),

--- a/crates/mentat-asserter/src/error.rs
+++ b/crates/mentat-asserter/src/error.rs
@@ -3,9 +3,9 @@
 use super::*;
 
 impl Asserter {
-    /// `error` ensures a [`NullableMentatError`] matches some error
+    /// `error` ensures a [`UncheckedMentatError`] matches some error
     /// provided in `/network/options`.
-    pub fn error(&self, err: Option<&NullableMentatError>) -> AssertResult<()> {
+    pub fn error(&self, err: Option<&UncheckedMentatError>) -> AssertResult<()> {
         let asserter = self
             .response
             .as_ref()

--- a/crates/mentat-asserter/src/error.rs
+++ b/crates/mentat-asserter/src/error.rs
@@ -3,9 +3,9 @@
 use super::*;
 
 impl Asserter {
-    /// `error` ensures a [`MentatError`] matches some error
+    /// `error` ensures a [`NullableMentatError`] matches some error
     /// provided in `/network/options`.
-    pub fn error(&self, err: Option<&MentatError>) -> AssertResult<()> {
+    pub fn error(&self, err: Option<&NullableMentatError>) -> AssertResult<()> {
         let asserter = self
             .response
             .as_ref()

--- a/crates/mentat-asserter/src/error_test.rs
+++ b/crates/mentat-asserter/src/error_test.rs
@@ -5,7 +5,7 @@ fn test_error_map() {
     let tests = vec![
         TestCase {
             name: "matching error",
-            payload: MentatError {
+            payload: NullableMentatError {
                 status_code: 0,
                 code: 10,
                 message: "error 10".to_string(),
@@ -19,7 +19,7 @@ fn test_error_map() {
         },
         TestCase {
             name: "empty description",
-            payload: MentatError {
+            payload: NullableMentatError {
                 status_code: 0,
                 code: 10,
                 message: "error 10".to_string(),
@@ -33,7 +33,7 @@ fn test_error_map() {
         },
         TestCase {
             name: "negative error",
-            payload: MentatError {
+            payload: NullableMentatError {
                 status_code: 0,
                 code: -1,
                 message: "error 10".to_string(),
@@ -47,7 +47,7 @@ fn test_error_map() {
         },
         TestCase {
             name: "retriable error",
-            payload: MentatError {
+            payload: NullableMentatError {
                 status_code: 0,
                 code: 10,
                 message: "error 10".to_string(),
@@ -61,7 +61,7 @@ fn test_error_map() {
         },
         TestCase {
             name: "code mismatch",
-            payload: MentatError {
+            payload: NullableMentatError {
                 status_code: 0,
                 code: 20,
                 message: "error 20".to_string(),
@@ -75,7 +75,7 @@ fn test_error_map() {
         },
         TestCase {
             name: "code mismatch",
-            payload: MentatError {
+            payload: NullableMentatError {
                 status_code: 0,
                 code: 10,
                 message: "error 11".to_string(),
@@ -96,12 +96,12 @@ fn test_error_map() {
             sub_network_identifier: None,
         }),
         Some(NullableNetworkStatusResponse {
-            current_block_identifier: Some(BlockIdentifier {
+            current_block_identifier: Some(NullableBlockIdentifier {
                 index: 100,
                 hash: "block 100".to_string(),
             }),
             current_block_timestamp: MIN_UNIX_EPOCH + 1,
-            genesis_block_identifier: Some(BlockIdentifier {
+            genesis_block_identifier: Some(NullableBlockIdentifier {
                 index: 0,
                 hash: "block 0".to_string(),
             }),
@@ -121,7 +121,7 @@ fn test_error_map() {
             }),
             allow: Some(NullableAllow {
                 errors: vec![
-                    Some(MentatError {
+                    Some(NullableMentatError {
                         status_code: 0,
                         code: 10,
                         message: "error 10".to_string(),
@@ -129,7 +129,7 @@ fn test_error_map() {
                         retriable: true,
                         details: Default::default(),
                     }),
-                    Some(MentatError {
+                    Some(NullableMentatError {
                         status_code: 0,
                         code: 1,
                         message: "error 1".to_string(),

--- a/crates/mentat-asserter/src/error_test.rs
+++ b/crates/mentat-asserter/src/error_test.rs
@@ -5,7 +5,7 @@ fn test_error_map() {
     let tests = vec![
         TestCase {
             name: "matching error",
-            payload: NullableMentatError {
+            payload: UncheckedMentatError {
                 status_code: 0,
                 code: 10,
                 message: "error 10".to_string(),
@@ -19,7 +19,7 @@ fn test_error_map() {
         },
         TestCase {
             name: "empty description",
-            payload: NullableMentatError {
+            payload: UncheckedMentatError {
                 status_code: 0,
                 code: 10,
                 message: "error 10".to_string(),
@@ -33,7 +33,7 @@ fn test_error_map() {
         },
         TestCase {
             name: "negative error",
-            payload: NullableMentatError {
+            payload: UncheckedMentatError {
                 status_code: 0,
                 code: -1,
                 message: "error 10".to_string(),
@@ -47,7 +47,7 @@ fn test_error_map() {
         },
         TestCase {
             name: "retriable error",
-            payload: NullableMentatError {
+            payload: UncheckedMentatError {
                 status_code: 0,
                 code: 10,
                 message: "error 10".to_string(),
@@ -61,7 +61,7 @@ fn test_error_map() {
         },
         TestCase {
             name: "code mismatch",
-            payload: NullableMentatError {
+            payload: UncheckedMentatError {
                 status_code: 0,
                 code: 20,
                 message: "error 20".to_string(),
@@ -75,7 +75,7 @@ fn test_error_map() {
         },
         TestCase {
             name: "code mismatch",
-            payload: NullableMentatError {
+            payload: UncheckedMentatError {
                 status_code: 0,
                 code: 10,
                 message: "error 11".to_string(),
@@ -95,13 +95,13 @@ fn test_error_map() {
             network: "WORLD".into(),
             sub_network_identifier: None,
         }),
-        Some(NullableNetworkStatusResponse {
-            current_block_identifier: Some(NullableBlockIdentifier {
+        Some(UncheckedNetworkStatusResponse {
+            current_block_identifier: Some(UncheckedBlockIdentifier {
                 index: 100,
                 hash: "block 100".to_string(),
             }),
             current_block_timestamp: MIN_UNIX_EPOCH + 1,
-            genesis_block_identifier: Some(NullableBlockIdentifier {
+            genesis_block_identifier: Some(UncheckedBlockIdentifier {
                 index: 0,
                 hash: "block 0".to_string(),
             }),
@@ -112,16 +112,16 @@ fn test_error_map() {
                 metadata: Default::default(),
             })],
         }),
-        Some(NullableNetworkOptionsResponse {
+        Some(UncheckedNetworkOptionsResponse {
             version: Some(Version {
                 rosetta_version: "1.4.0".to_string(),
                 node_version: "1.0".to_string(),
                 middleware_version: None,
                 metadata: Default::default(),
             }),
-            allow: Some(NullableAllow {
+            allow: Some(UncheckedAllow {
                 errors: vec![
-                    Some(NullableMentatError {
+                    Some(UncheckedMentatError {
                         status_code: 0,
                         code: 10,
                         message: "error 10".to_string(),
@@ -129,7 +129,7 @@ fn test_error_map() {
                         retriable: true,
                         details: Default::default(),
                     }),
-                    Some(NullableMentatError {
+                    Some(UncheckedMentatError {
                         status_code: 0,
                         code: 1,
                         message: "error 1".to_string(),

--- a/crates/mentat-asserter/src/events.rs
+++ b/crates/mentat-asserter/src/events.rs
@@ -38,7 +38,7 @@ pub fn events_blocks_response(response: Option<&NullableEventsBlocksResponse>) -
         if seq == -1 {
             seq = event.sequence
         }
-        if event.sequence != seq + (i as i64) {
+        if event.sequence != seq + (i as isize) {
             Err(EventError::SequenceOutOfOrder)?;
         }
     }

--- a/crates/mentat-asserter/src/events.rs
+++ b/crates/mentat-asserter/src/events.rs
@@ -4,7 +4,7 @@ use super::*;
 
 /// [`BlockEvent`] ensures a *types.BlockEvent
 /// is valid.
-pub fn block_event(event: Option<&NullableBlockEvent>) -> AssertResult<()> {
+pub fn block_event(event: Option<&UncheckedBlockEvent>) -> AssertResult<()> {
     // TODO coinbase never checks if event nil
     let event = event.unwrap();
 
@@ -23,7 +23,9 @@ pub fn block_event(event: Option<&NullableBlockEvent>) -> AssertResult<()> {
 
 /// events_blocks_response ensures a [`EventsBlocksResponse`]
 /// is valid.
-pub fn events_blocks_response(response: Option<&NullableEventsBlocksResponse>) -> AssertResult<()> {
+pub fn events_blocks_response(
+    response: Option<&UncheckedEventsBlocksResponse>,
+) -> AssertResult<()> {
     // TODO: coinbase never checks for nil
     let response = response.unwrap();
 

--- a/crates/mentat-asserter/src/events_test.rs
+++ b/crates/mentat-asserter/src/events_test.rs
@@ -23,7 +23,7 @@ fn test_events_block_response() {
                 events: vec![
                     Some(NullableBlockEvent {
                         sequence: 0,
-                        block_identifier: Some(BlockIdentifier {
+                        block_identifier: Some(NullableBlockIdentifier {
                             index: 0,
                             hash: 0.to_string(),
                         }),
@@ -31,7 +31,7 @@ fn test_events_block_response() {
                     }),
                     Some(NullableBlockEvent {
                         sequence: 1,
-                        block_identifier: Some(BlockIdentifier {
+                        block_identifier: Some(NullableBlockIdentifier {
                             index: 0,
                             hash: 0.to_string(),
                         }),
@@ -48,7 +48,7 @@ fn test_events_block_response() {
                 events: vec![
                     Some(NullableBlockEvent {
                         sequence: 0,
-                        block_identifier: Some(BlockIdentifier {
+                        block_identifier: Some(NullableBlockIdentifier {
                             index: 0,
                             hash: String::new(),
                         }),
@@ -56,7 +56,7 @@ fn test_events_block_response() {
                     }),
                     Some(NullableBlockEvent {
                         sequence: 1,
-                        block_identifier: Some(BlockIdentifier {
+                        block_identifier: Some(NullableBlockIdentifier {
                             index: 0,
                             hash: 0.to_string(),
                         }),
@@ -73,7 +73,7 @@ fn test_events_block_response() {
                 events: vec![
                     Some(NullableBlockEvent {
                         sequence: 0,
-                        block_identifier: Some(BlockIdentifier {
+                        block_identifier: Some(NullableBlockIdentifier {
                             index: 0,
                             hash: 0.to_string(),
                         }),
@@ -81,7 +81,7 @@ fn test_events_block_response() {
                     }),
                     Some(NullableBlockEvent {
                         sequence: 1,
-                        block_identifier: Some(BlockIdentifier {
+                        block_identifier: Some(NullableBlockIdentifier {
                             index: 0,
                             hash: 0.to_string(),
                         }),
@@ -98,7 +98,7 @@ fn test_events_block_response() {
                 events: vec![
                     Some(NullableBlockEvent {
                         sequence: 0,
-                        block_identifier: Some(BlockIdentifier {
+                        block_identifier: Some(NullableBlockIdentifier {
                             index: 0,
                             hash: 0.to_string(),
                         }),
@@ -106,7 +106,7 @@ fn test_events_block_response() {
                     }),
                     Some(NullableBlockEvent {
                         sequence: 2,
-                        block_identifier: Some(BlockIdentifier {
+                        block_identifier: Some(NullableBlockIdentifier {
                             index: 0,
                             hash: 0.to_string(),
                         }),
@@ -123,7 +123,7 @@ fn test_events_block_response() {
                 events: vec![
                     Some(NullableBlockEvent {
                         sequence: -1,
-                        block_identifier: Some(BlockIdentifier {
+                        block_identifier: Some(NullableBlockIdentifier {
                             index: 0,
                             hash: 0.to_string(),
                         }),
@@ -131,7 +131,7 @@ fn test_events_block_response() {
                     }),
                     Some(NullableBlockEvent {
                         sequence: 0,
-                        block_identifier: Some(BlockIdentifier {
+                        block_identifier: Some(NullableBlockIdentifier {
                             index: 0,
                             hash: 0.to_string(),
                         }),

--- a/crates/mentat-asserter/src/events_test.rs
+++ b/crates/mentat-asserter/src/events_test.rs
@@ -10,7 +10,7 @@ fn test_events_block_response() {
         },
         TestCase {
             name: "invalid max",
-            payload: NullableEventsBlocksResponse {
+            payload: UncheckedEventsBlocksResponse {
                 max_sequence: -1,
                 events: Vec::new(),
             },
@@ -18,24 +18,24 @@ fn test_events_block_response() {
         },
         TestCase {
             name: "valid event",
-            payload: NullableEventsBlocksResponse {
+            payload: UncheckedEventsBlocksResponse {
                 max_sequence: 100,
                 events: vec![
-                    Some(NullableBlockEvent {
+                    Some(UncheckedBlockEvent {
                         sequence: 0,
-                        block_identifier: Some(NullableBlockIdentifier {
+                        block_identifier: Some(UncheckedBlockIdentifier {
                             index: 0,
                             hash: 0.to_string(),
                         }),
-                        type_: NullableBlockEventType::BLOCK_ADDED.into(),
+                        type_: UncheckedBlockEventType::BLOCK_ADDED.into(),
                     }),
-                    Some(NullableBlockEvent {
+                    Some(UncheckedBlockEvent {
                         sequence: 1,
-                        block_identifier: Some(NullableBlockIdentifier {
+                        block_identifier: Some(UncheckedBlockIdentifier {
                             index: 0,
                             hash: 0.to_string(),
                         }),
-                        type_: NullableBlockEventType::BLOCK_REMOVED.into(),
+                        type_: UncheckedBlockEventType::BLOCK_REMOVED.into(),
                     }),
                 ],
             },
@@ -43,24 +43,24 @@ fn test_events_block_response() {
         },
         TestCase {
             name: "invalid identifier",
-            payload: NullableEventsBlocksResponse {
+            payload: UncheckedEventsBlocksResponse {
                 max_sequence: 100,
                 events: vec![
-                    Some(NullableBlockEvent {
+                    Some(UncheckedBlockEvent {
                         sequence: 0,
-                        block_identifier: Some(NullableBlockIdentifier {
+                        block_identifier: Some(UncheckedBlockIdentifier {
                             index: 0,
                             hash: String::new(),
                         }),
-                        type_: NullableBlockEventType::BLOCK_ADDED.into(),
+                        type_: UncheckedBlockEventType::BLOCK_ADDED.into(),
                     }),
-                    Some(NullableBlockEvent {
+                    Some(UncheckedBlockEvent {
                         sequence: 1,
-                        block_identifier: Some(NullableBlockIdentifier {
+                        block_identifier: Some(UncheckedBlockIdentifier {
                             index: 0,
                             hash: 0.to_string(),
                         }),
-                        type_: NullableBlockEventType::BLOCK_REMOVED.into(),
+                        type_: UncheckedBlockEventType::BLOCK_REMOVED.into(),
                     }),
                 ],
             },
@@ -68,24 +68,24 @@ fn test_events_block_response() {
         },
         TestCase {
             name: "invalid event type",
-            payload: NullableEventsBlocksResponse {
+            payload: UncheckedEventsBlocksResponse {
                 max_sequence: 100,
                 events: vec![
-                    Some(NullableBlockEvent {
+                    Some(UncheckedBlockEvent {
                         sequence: 0,
-                        block_identifier: Some(NullableBlockIdentifier {
+                        block_identifier: Some(UncheckedBlockIdentifier {
                             index: 0,
                             hash: 0.to_string(),
                         }),
                         type_: "revert".into(),
                     }),
-                    Some(NullableBlockEvent {
+                    Some(UncheckedBlockEvent {
                         sequence: 1,
-                        block_identifier: Some(NullableBlockIdentifier {
+                        block_identifier: Some(UncheckedBlockIdentifier {
                             index: 0,
                             hash: 0.to_string(),
                         }),
-                        type_: NullableBlockEventType::BLOCK_REMOVED.into(),
+                        type_: UncheckedBlockEventType::BLOCK_REMOVED.into(),
                     }),
                 ],
             },
@@ -93,24 +93,24 @@ fn test_events_block_response() {
         },
         TestCase {
             name: "gap events",
-            payload: NullableEventsBlocksResponse {
+            payload: UncheckedEventsBlocksResponse {
                 max_sequence: 100,
                 events: vec![
-                    Some(NullableBlockEvent {
+                    Some(UncheckedBlockEvent {
                         sequence: 0,
-                        block_identifier: Some(NullableBlockIdentifier {
+                        block_identifier: Some(UncheckedBlockIdentifier {
                             index: 0,
                             hash: 0.to_string(),
                         }),
-                        type_: NullableBlockEventType::BLOCK_ADDED.into(),
+                        type_: UncheckedBlockEventType::BLOCK_ADDED.into(),
                     }),
-                    Some(NullableBlockEvent {
+                    Some(UncheckedBlockEvent {
                         sequence: 2,
-                        block_identifier: Some(NullableBlockIdentifier {
+                        block_identifier: Some(UncheckedBlockIdentifier {
                             index: 0,
                             hash: 0.to_string(),
                         }),
-                        type_: NullableBlockEventType::BLOCK_REMOVED.into(),
+                        type_: UncheckedBlockEventType::BLOCK_REMOVED.into(),
                     }),
                 ],
             },
@@ -118,24 +118,24 @@ fn test_events_block_response() {
         },
         TestCase {
             name: "gap events",
-            payload: NullableEventsBlocksResponse {
+            payload: UncheckedEventsBlocksResponse {
                 max_sequence: 100,
                 events: vec![
-                    Some(NullableBlockEvent {
+                    Some(UncheckedBlockEvent {
                         sequence: -1,
-                        block_identifier: Some(NullableBlockIdentifier {
+                        block_identifier: Some(UncheckedBlockIdentifier {
                             index: 0,
                             hash: 0.to_string(),
                         }),
-                        type_: NullableBlockEventType::BLOCK_ADDED.into(),
+                        type_: UncheckedBlockEventType::BLOCK_ADDED.into(),
                     }),
-                    Some(NullableBlockEvent {
+                    Some(UncheckedBlockEvent {
                         sequence: 0,
-                        block_identifier: Some(NullableBlockIdentifier {
+                        block_identifier: Some(UncheckedBlockIdentifier {
                             index: 0,
                             hash: 0.to_string(),
                         }),
-                        type_: NullableBlockEventType::BLOCK_REMOVED.into(),
+                        type_: UncheckedBlockEventType::BLOCK_REMOVED.into(),
                     }),
                 ],
             },

--- a/crates/mentat-asserter/src/network.rs
+++ b/crates/mentat-asserter/src/network.rs
@@ -64,8 +64,8 @@ pub fn version(version: Option<&Version>) -> AssertResult<()> {
     Ok(())
 }
 
-/// `sync_status` ensures any [`SyncStatus`] is valid.
-pub fn sync_status(status: Option<&SyncStatus>) -> AssertResult<()> {
+/// `sync_status` ensures any [`NullableSyncStatus`] is valid.
+pub fn sync_status(status: Option<&NullableSyncStatus>) -> AssertResult<()> {
     let status = match status {
         Some(s) => s,
         None => return Ok(()),
@@ -92,7 +92,7 @@ pub fn network_status_response(resp: Option<&NullableNetworkStatusResponse>) -> 
     let resp = resp.ok_or(NetworkError::NetworkStatusResponseIsNil)?;
 
     block_identifier(resp.current_block_identifier.as_ref())?;
-    timestamp(resp.current_block_timestamp as i64)?;
+    timestamp(resp.current_block_timestamp as isize)?;
     block_identifier(resp.genesis_block_identifier.as_ref())?;
     resp.peers
         .iter()
@@ -139,8 +139,8 @@ pub fn operation_types(types: &[String]) -> AssertResult<()> {
     string_array("Allow.OperationTypes", types).map_err(AsserterError::from)
 }
 
-/// `error` ensures a [`MentatError`] is valid.
-pub fn error(err: Option<&MentatError>) -> AssertResult<()> {
+/// `error` ensures a [`NullableMentatError`] is valid.
+pub fn error(err: Option<&NullableMentatError>) -> AssertResult<()> {
     let err = err.ok_or(ErrorError::IsNil)?;
 
     if err.code < 0 {
@@ -154,9 +154,9 @@ pub fn error(err: Option<&MentatError>) -> AssertResult<()> {
     }
 }
 
-/// `errors` ensures each [`MentatError`] in a slice is valid
+/// `errors` ensures each [`NullableMentatError`] in a slice is valid
 /// and that there is no error code collision.
-pub fn errors(errors: &[Option<MentatError>]) -> AssertResult<()> {
+pub fn errors(errors: &[Option<NullableMentatError>]) -> AssertResult<()> {
     let mut status_codes = IndexSet::new();
 
     for err in errors {

--- a/crates/mentat-asserter/src/network.rs
+++ b/crates/mentat-asserter/src/network.rs
@@ -64,8 +64,8 @@ pub fn version(version: Option<&Version>) -> AssertResult<()> {
     Ok(())
 }
 
-/// `sync_status` ensures any [`NullableSyncStatus`] is valid.
-pub fn sync_status(status: Option<&NullableSyncStatus>) -> AssertResult<()> {
+/// `sync_status` ensures any [`UncheckedSyncStatus`] is valid.
+pub fn sync_status(status: Option<&UncheckedSyncStatus>) -> AssertResult<()> {
     let status = match status {
         Some(s) => s,
         None => return Ok(()),
@@ -88,7 +88,7 @@ pub fn sync_status(status: Option<&NullableSyncStatus>) -> AssertResult<()> {
 
 /// `network_status_response` ensures any [`NetworkStatusResponse`]
 /// is valid.
-pub fn network_status_response(resp: Option<&NullableNetworkStatusResponse>) -> AssertResult<()> {
+pub fn network_status_response(resp: Option<&UncheckedNetworkStatusResponse>) -> AssertResult<()> {
     let resp = resp.ok_or(NetworkError::NetworkStatusResponseIsNil)?;
 
     block_identifier(resp.current_block_identifier.as_ref())?;
@@ -139,8 +139,8 @@ pub fn operation_types(types: &[String]) -> AssertResult<()> {
     string_array("Allow.OperationTypes", types).map_err(AsserterError::from)
 }
 
-/// `error` ensures a [`NullableMentatError`] is valid.
-pub fn error(err: Option<&NullableMentatError>) -> AssertResult<()> {
+/// `error` ensures a [`UncheckedMentatError`] is valid.
+pub fn error(err: Option<&UncheckedMentatError>) -> AssertResult<()> {
     let err = err.ok_or(ErrorError::IsNil)?;
 
     if err.code < 0 {
@@ -154,9 +154,9 @@ pub fn error(err: Option<&NullableMentatError>) -> AssertResult<()> {
     }
 }
 
-/// `errors` ensures each [`NullableMentatError`] in a slice is valid
+/// `errors` ensures each [`UncheckedMentatError`] in a slice is valid
 /// and that there is no error code collision.
-pub fn errors(errors: &[Option<NullableMentatError>]) -> AssertResult<()> {
+pub fn errors(errors: &[Option<UncheckedMentatError>]) -> AssertResult<()> {
     let mut status_codes = IndexSet::new();
 
     for err in errors {
@@ -178,7 +178,7 @@ pub fn errors(errors: &[Option<NullableMentatError>]) -> AssertResult<()> {
 }
 
 /// `balance_exemptions` ensures [`BalanceExemption`]] in a slice is valid.
-pub fn balance_exemptions(exemptions: &[Option<NullableBalanceExemption>]) -> AssertResult<()> {
+pub fn balance_exemptions(exemptions: &[Option<UncheckedBalanceExemption>]) -> AssertResult<()> {
     for (index, exemption) in exemptions.iter().enumerate() {
         let exemption = exemption.as_ref().ok_or(format!(
             "{} (index {})",
@@ -230,7 +230,7 @@ pub fn call_methods(methods: &[String]) -> AssertResult<()> {
 }
 
 /// `allow` ensures a [`Allow`] object is valid.
-pub fn allow(allowed: Option<&NullableAllow>) -> AssertResult<()> {
+pub fn allow(allowed: Option<&UncheckedAllow>) -> AssertResult<()> {
     let allowed = allowed.ok_or(NetworkError::AllowIsNil)?;
 
     operation_statuses(&allowed.operation_statuses)?;
@@ -257,7 +257,7 @@ pub fn allow(allowed: Option<&NullableAllow>) -> AssertResult<()> {
 /// `network_options_response` ensures a [`NetworkOptionsResponse`] object is
 /// valid.
 pub fn network_options_response(
-    options: Option<&NullableNetworkOptionsResponse>,
+    options: Option<&UncheckedNetworkOptionsResponse>,
 ) -> AssertResult<()> {
     let options = options.ok_or(NetworkError::NetworkOptionsResponseIsNil)?;
     version(options.version.as_ref())?;
@@ -279,7 +279,7 @@ pub fn contains_network_identifier(
 }
 
 /// `network_list_response` ensures a [`NetworkListResponse`] object is valid.
-pub fn network_list_response(resp: Option<&NullableNetworkListResponse>) -> AssertResult<()> {
+pub fn network_list_response(resp: Option<&UncheckedNetworkListResponse>) -> AssertResult<()> {
     let resp = resp.ok_or(NetworkError::NetworkListResponseIsNil)?;
     let mut seen = Vec::new();
     for network in &resp.network_identifiers {

--- a/crates/mentat-asserter/src/network_test.rs
+++ b/crates/mentat-asserter/src/network_test.rs
@@ -140,14 +140,14 @@ fn test_allow() {
     ];
     let operation_types = vec!["PAYMENT".to_string()];
     let call_methods = vec!["call".to_string()];
-    let balance_exemptions = vec![Some(NullableBalanceExemption {
+    let balance_exemptions = vec![Some(UncheckedBalanceExemption {
         sub_account_address: None,
-        currency: Some(NullableCurrency {
+        currency: Some(UncheckedCurrency {
             symbol: "BTC".to_string(),
             decimals: 8,
             metadata: Default::default(),
         }),
-        exemption_type: NullableExemptionType::DYNAMIC.into(),
+        exemption_type: UncheckedExemptionType::DYNAMIC.into(),
     })];
     let neg_index = Some(-1);
     let index = Some(100);
@@ -155,7 +155,7 @@ fn test_allow() {
     let tests = vec![
         TestCase {
             name: "valid Allow",
-            payload: Some(NullableAllow {
+            payload: Some(UncheckedAllow {
                 operation_statuses: operation_statuses.clone(),
                 operation_types: operation_types.clone(),
                 ..Default::default()
@@ -164,7 +164,7 @@ fn test_allow() {
         },
         TestCase {
             name: "valid Allow with call methods and exemptions",
-            payload: Some(NullableAllow {
+            payload: Some(UncheckedAllow {
                 operation_statuses: operation_statuses.clone(),
                 operation_types: operation_types.clone(),
                 call_methods: call_methods.clone(),
@@ -177,7 +177,7 @@ fn test_allow() {
         },
         TestCase {
             name: "valid Allow with exemptions and no historical",
-            payload: Some(NullableAllow {
+            payload: Some(UncheckedAllow {
                 operation_statuses: operation_statuses.clone(),
                 operation_types: operation_types.clone(),
                 call_methods,
@@ -188,7 +188,7 @@ fn test_allow() {
         },
         TestCase {
             name: "invalid timestamp start index",
-            payload: Some(NullableAllow {
+            payload: Some(UncheckedAllow {
                 operation_statuses: operation_statuses.clone(),
                 operation_types: operation_types.clone(),
                 timestamp_start_index: neg_index,
@@ -203,7 +203,7 @@ fn test_allow() {
         },
         TestCase {
             name: "no OperationStatuses",
-            payload: Some(NullableAllow {
+            payload: Some(UncheckedAllow {
                 operation_types: operation_types.clone(),
                 ..Default::default()
             }),
@@ -211,7 +211,7 @@ fn test_allow() {
         },
         TestCase {
             name: "no successful OperationStatuses",
-            payload: Some(NullableAllow {
+            payload: Some(UncheckedAllow {
                 operation_statuses: vec![operation_statuses[1].clone()],
                 operation_types: operation_types.clone(),
                 ..Default::default()
@@ -220,7 +220,7 @@ fn test_allow() {
         },
         TestCase {
             name: "no OperationTypes",
-            payload: Some(NullableAllow {
+            payload: Some(UncheckedAllow {
                 operation_statuses: operation_statuses.clone(),
                 ..Default::default()
             }),
@@ -230,7 +230,7 @@ fn test_allow() {
         },
         TestCase {
             name: "duplicate call methods",
-            payload: Some(NullableAllow {
+            payload: Some(UncheckedAllow {
                 operation_statuses: operation_statuses.clone(),
                 operation_types: operation_types.clone(),
                 call_methods: vec!["call".into(), "call".into()],
@@ -243,14 +243,14 @@ fn test_allow() {
         },
         TestCase {
             name: "empty exemption",
-            payload: Some(NullableAllow {
+            payload: Some(UncheckedAllow {
                 operation_statuses: operation_statuses.clone(),
                 operation_types: operation_types.clone(),
                 call_methods: vec!["call".into()],
-                balance_exemptions: vec![Some(NullableBalanceExemption {
+                balance_exemptions: vec![Some(UncheckedBalanceExemption {
                     sub_account_address: None,
                     currency: None,
-                    exemption_type: NullableExemptionType::DYNAMIC.into(),
+                    exemption_type: UncheckedExemptionType::DYNAMIC.into(),
                 })],
                 ..Default::default()
             }),
@@ -258,11 +258,11 @@ fn test_allow() {
         },
         TestCase {
             name: "invalid exemption type",
-            payload: Some(NullableAllow {
+            payload: Some(UncheckedAllow {
                 operation_statuses,
                 operation_types,
                 call_methods: vec!["call".into()],
-                balance_exemptions: vec![Some(NullableBalanceExemption {
+                balance_exemptions: vec![Some(UncheckedBalanceExemption {
                     sub_account_address: None,
                     currency: None,
                     exemption_type: "test".into(),
@@ -281,7 +281,7 @@ fn test_error() {
     let tests = vec![
         TestCase {
             name: "valid error",
-            payload: Some(NullableMentatError {
+            payload: Some(UncheckedMentatError {
                 code: 12,
                 message: "signature invalid".into(),
                 ..Default::default()
@@ -295,7 +295,7 @@ fn test_error() {
         },
         TestCase {
             name: "negative code",
-            payload: Some(NullableMentatError {
+            payload: Some(UncheckedMentatError {
                 code: -1,
                 message: "signature invalid".into(),
                 ..Default::default()
@@ -304,7 +304,7 @@ fn test_error() {
         },
         TestCase {
             name: "empty message",
-            payload: Some(NullableMentatError {
+            payload: Some(UncheckedMentatError {
                 code: 0,
                 message: String::new(),
                 ..Default::default()
@@ -322,12 +322,12 @@ fn test_errors() {
         TestCase {
             name: "valid errors",
             payload: vec![
-                Some(NullableMentatError {
+                Some(UncheckedMentatError {
                     code: 0,
                     message: "error 1".into(),
                     ..Default::default()
                 }),
-                Some(NullableMentatError {
+                Some(UncheckedMentatError {
                     code: 2,
                     message: "error 2".into(),
                     ..Default::default()
@@ -338,7 +338,7 @@ fn test_errors() {
         TestCase {
             name: "details populated",
             payload: vec![
-                Some(NullableMentatError {
+                Some(UncheckedMentatError {
                     code: 0,
                     message: "error 1".into(),
                     details: indexmap!(
@@ -346,7 +346,7 @@ fn test_errors() {
                     ),
                     ..Default::default()
                 }),
-                Some(NullableMentatError {
+                Some(UncheckedMentatError {
                     code: 1,
                     message: "error 2".into(),
                     ..Default::default()
@@ -357,12 +357,12 @@ fn test_errors() {
         TestCase {
             name: "duplicate error codes",
             payload: vec![
-                Some(NullableMentatError {
+                Some(UncheckedMentatError {
                     code: 0,
                     message: "error 1".into(),
                     ..Default::default()
                 }),
-                Some(NullableMentatError {
+                Some(UncheckedMentatError {
                     code: 0,
                     message: "error 2".into(),
                     ..Default::default()
@@ -402,7 +402,7 @@ fn test_network_list_response() {
     let tests = vec![
         TestCase {
             name: "valid network list",
-            payload: Some(NullableNetworkListResponse {
+            payload: Some(UncheckedNetworkListResponse {
                 network_identifiers: vec![network_1, network_1_sub.clone(), network_2],
             }),
             criteria: None,
@@ -414,14 +414,14 @@ fn test_network_list_response() {
         },
         TestCase {
             name: "network list duplicate",
-            payload: Some(NullableNetworkListResponse {
+            payload: Some(UncheckedNetworkListResponse {
                 network_identifiers: vec![network_1_sub.clone(), network_1_sub],
             }),
             criteria: Some(NetworkError::NetworkListResponseNetworksContainsDuplicates.into()),
         },
         TestCase {
             name: "invalid network",
-            payload: Some(NullableNetworkListResponse {
+            payload: Some(UncheckedNetworkListResponse {
                 network_identifiers: vec![network_3],
             }),
             criteria: Some(NetworkError::NetworkIdentifierBlockchainMissing.into()),

--- a/crates/mentat-asserter/src/network_test.rs
+++ b/crates/mentat-asserter/src/network_test.rs
@@ -281,7 +281,7 @@ fn test_error() {
     let tests = vec![
         TestCase {
             name: "valid error",
-            payload: Some(MentatError {
+            payload: Some(NullableMentatError {
                 code: 12,
                 message: "signature invalid".into(),
                 ..Default::default()
@@ -295,7 +295,7 @@ fn test_error() {
         },
         TestCase {
             name: "negative code",
-            payload: Some(MentatError {
+            payload: Some(NullableMentatError {
                 code: -1,
                 message: "signature invalid".into(),
                 ..Default::default()
@@ -304,7 +304,7 @@ fn test_error() {
         },
         TestCase {
             name: "empty message",
-            payload: Some(MentatError {
+            payload: Some(NullableMentatError {
                 code: 0,
                 message: String::new(),
                 ..Default::default()
@@ -322,12 +322,12 @@ fn test_errors() {
         TestCase {
             name: "valid errors",
             payload: vec![
-                Some(MentatError {
+                Some(NullableMentatError {
                     code: 0,
                     message: "error 1".into(),
                     ..Default::default()
                 }),
-                Some(MentatError {
+                Some(NullableMentatError {
                     code: 2,
                     message: "error 2".into(),
                     ..Default::default()
@@ -338,7 +338,7 @@ fn test_errors() {
         TestCase {
             name: "details populated",
             payload: vec![
-                Some(MentatError {
+                Some(NullableMentatError {
                     code: 0,
                     message: "error 1".into(),
                     details: indexmap!(
@@ -346,7 +346,7 @@ fn test_errors() {
                     ),
                     ..Default::default()
                 }),
-                Some(MentatError {
+                Some(NullableMentatError {
                     code: 1,
                     message: "error 2".into(),
                     ..Default::default()
@@ -357,12 +357,12 @@ fn test_errors() {
         TestCase {
             name: "duplicate error codes",
             payload: vec![
-                Some(MentatError {
+                Some(NullableMentatError {
                     code: 0,
                     message: "error 1".into(),
                     ..Default::default()
                 }),
-                Some(MentatError {
+                Some(NullableMentatError {
                     code: 0,
                     message: "error 2".into(),
                     ..Default::default()

--- a/crates/mentat-asserter/src/search.rs
+++ b/crates/mentat-asserter/src/search.rs
@@ -7,7 +7,7 @@ impl Asserter {
     /// *types.SearchTransactionsResponse is valid.
     pub fn search_transaction_response(
         &self,
-        response: Option<&NullableSearchTransactionsResponse>,
+        response: Option<&UncheckedSearchTransactionsResponse>,
     ) -> AssertResult<()> {
         self.response
             .as_ref()

--- a/crates/mentat-asserter/src/search_test.rs
+++ b/crates/mentat-asserter/src/search_test.rs
@@ -8,7 +8,7 @@ fn test_search_transactions_response() {
         }),
         operations: vec![
             Some(NullableOperation {
-                operation_identifier: Some(OperationIdentifier {
+                operation_identifier: Some(NullableOperationIdentifier {
                     index: 0,
                     network_index: None,
                 }),
@@ -19,11 +19,11 @@ fn test_search_transactions_response() {
                 ..Default::default()
             }),
             Some(NullableOperation {
-                operation_identifier: Some(OperationIdentifier {
+                operation_identifier: Some(NullableOperationIdentifier {
                     index: 1,
                     network_index: None,
                 }),
-                related_operations: vec![Some(OperationIdentifier {
+                related_operations: vec![Some(NullableOperationIdentifier {
                     index: 0,
                     network_index: None,
                 })],
@@ -120,12 +120,12 @@ fn test_search_transactions_response() {
             sub_network_identifier: None,
         }),
         Some(NullableNetworkStatusResponse {
-            current_block_identifier: Some(BlockIdentifier {
+            current_block_identifier: Some(NullableBlockIdentifier {
                 index: 100,
                 hash: "block 100".into(),
             }),
             current_block_timestamp: MIN_UNIX_EPOCH + 1,
-            genesis_block_identifier: Some(BlockIdentifier {
+            genesis_block_identifier: Some(NullableBlockIdentifier {
                 index: 0,
                 hash: "block 0".into(),
             }),

--- a/crates/mentat-asserter/src/search_test.rs
+++ b/crates/mentat-asserter/src/search_test.rs
@@ -2,13 +2,13 @@ use super::*;
 
 #[test]
 fn test_search_transactions_response() {
-    let valid_transaction = Some(NullableTransaction {
+    let valid_transaction = Some(UncheckedTransaction {
         transaction_identifier: Some(TransactionIdentifier {
             hash: "blah".into(),
         }),
         operations: vec![
-            Some(NullableOperation {
-                operation_identifier: Some(NullableOperationIdentifier {
+            Some(UncheckedOperation {
+                operation_identifier: Some(UncheckedOperationIdentifier {
                     index: 0,
                     network_index: None,
                 }),
@@ -18,12 +18,12 @@ fn test_search_transactions_response() {
                 amount: valid_amount(),
                 ..Default::default()
             }),
-            Some(NullableOperation {
-                operation_identifier: Some(NullableOperationIdentifier {
+            Some(UncheckedOperation {
+                operation_identifier: Some(UncheckedOperationIdentifier {
                     index: 1,
                     network_index: None,
                 }),
-                related_operations: vec![Some(NullableOperationIdentifier {
+                related_operations: vec![Some(UncheckedOperationIdentifier {
                     index: 0,
                     network_index: None,
                 })],
@@ -45,7 +45,7 @@ fn test_search_transactions_response() {
         },
         TestCase {
             name: "valid next",
-            payload: NullableSearchTransactionsResponse {
+            payload: UncheckedSearchTransactionsResponse {
                 next_offset: Some(1),
                 ..Default::default()
             },
@@ -53,7 +53,7 @@ fn test_search_transactions_response() {
         },
         TestCase {
             name: "invalid next",
-            payload: NullableSearchTransactionsResponse {
+            payload: UncheckedSearchTransactionsResponse {
                 next_offset: Some(-1),
                 ..Default::default()
             },
@@ -61,7 +61,7 @@ fn test_search_transactions_response() {
         },
         TestCase {
             name: "valid count",
-            payload: NullableSearchTransactionsResponse {
+            payload: UncheckedSearchTransactionsResponse {
                 total_count: 0,
                 ..Default::default()
             },
@@ -69,7 +69,7 @@ fn test_search_transactions_response() {
         },
         TestCase {
             name: "invalid count",
-            payload: NullableSearchTransactionsResponse {
+            payload: UncheckedSearchTransactionsResponse {
                 total_count: -1,
                 ..Default::default()
             },
@@ -77,9 +77,9 @@ fn test_search_transactions_response() {
         },
         TestCase {
             name: "valid next + transaction",
-            payload: NullableSearchTransactionsResponse {
+            payload: UncheckedSearchTransactionsResponse {
                 next_offset: Some(1),
-                transactions: vec![Some(NullableBlockTransaction {
+                transactions: vec![Some(UncheckedBlockTransaction {
                     block_identifier: valid_block_identifier(),
                     transaction: valid_transaction.clone(),
                 })],
@@ -89,9 +89,9 @@ fn test_search_transactions_response() {
         },
         TestCase {
             name: "valid next + invalid blockIdentifier",
-            payload: NullableSearchTransactionsResponse {
+            payload: UncheckedSearchTransactionsResponse {
                 next_offset: Some(1),
-                transactions: vec![Some(NullableBlockTransaction {
+                transactions: vec![Some(UncheckedBlockTransaction {
                     block_identifier: Some(Default::default()),
                     transaction: valid_transaction,
                 })],
@@ -101,9 +101,9 @@ fn test_search_transactions_response() {
         },
         TestCase {
             name: "valid next + invalid transaction",
-            payload: NullableSearchTransactionsResponse {
+            payload: UncheckedSearchTransactionsResponse {
                 next_offset: Some(1),
-                transactions: vec![Some(NullableBlockTransaction {
+                transactions: vec![Some(UncheckedBlockTransaction {
                     block_identifier: valid_block_identifier(),
                     transaction: Some(Default::default()),
                 })],
@@ -119,13 +119,13 @@ fn test_search_transactions_response() {
             network: "WORLD".into(),
             sub_network_identifier: None,
         }),
-        Some(NullableNetworkStatusResponse {
-            current_block_identifier: Some(NullableBlockIdentifier {
+        Some(UncheckedNetworkStatusResponse {
+            current_block_identifier: Some(UncheckedBlockIdentifier {
                 index: 100,
                 hash: "block 100".into(),
             }),
             current_block_timestamp: MIN_UNIX_EPOCH + 1,
-            genesis_block_identifier: Some(NullableBlockIdentifier {
+            genesis_block_identifier: Some(UncheckedBlockIdentifier {
                 index: 0,
                 hash: "block 0".into(),
             }),
@@ -136,14 +136,14 @@ fn test_search_transactions_response() {
                 metadata: Default::default(),
             })],
         }),
-        Some(NullableNetworkOptionsResponse {
+        Some(UncheckedNetworkOptionsResponse {
             version: Some(Version {
                 rosetta_version: "1.4.0".into(),
                 node_version: "1.0".into(),
                 middleware_version: None,
                 metadata: Default::default(),
             }),
-            allow: Some(NullableAllow {
+            allow: Some(UncheckedAllow {
                 operation_statuses: vec![
                     Some(OperationStatus {
                         status: "SUCCESS".into(),

--- a/crates/mentat-asserter/src/server.rs
+++ b/crates/mentat-asserter/src/server.rs
@@ -59,7 +59,7 @@ impl Asserter {
     /// is well-formatted.
     pub fn account_balance_request(
         &self,
-        request: Option<&NullableAccountBalanceRequest>,
+        request: Option<&UncheckedAccountBalanceRequest>,
     ) -> AssertResult<()> {
         let asserter = self.request.as_ref().ok_or(AsserterError::NotInitialized)?;
 
@@ -86,7 +86,7 @@ impl Asserter {
 
     /// [`block_request`] ensures that a [`BlockRequest`]
     /// is well-formatted.
-    pub fn block_request(&self, request: Option<&NullableBlockRequest>) -> AssertResult<()> {
+    pub fn block_request(&self, request: Option<&UncheckedBlockRequest>) -> AssertResult<()> {
         self.request.as_ref().ok_or(AsserterError::NotInitialized)?;
         let request = request.ok_or(ServerError::BlockRequestIsNil)?;
         self.valid_supported_network(request.network_identifier.as_ref())?;
@@ -97,7 +97,7 @@ impl Asserter {
     /// is well-formatted.
     pub fn block_transaction_request(
         &self,
-        request: Option<&NullableBlockTransactionRequest>,
+        request: Option<&UncheckedBlockTransactionRequest>,
     ) -> AssertResult<()> {
         self.request.as_ref().ok_or(AsserterError::NotInitialized)?;
         let request = request.ok_or(ServerError::BlockTransactionRequestIsNil)?;
@@ -110,7 +110,7 @@ impl Asserter {
     /// [`ConstructionMetadataRequest`] is well-formatted.
     pub fn construction_metadata_request(
         &self,
-        request: Option<&NullableConstructionMetadataRequest>,
+        request: Option<&UncheckedConstructionMetadataRequest>,
     ) -> AssertResult<()> {
         self.request.as_ref().ok_or(AsserterError::NotInitialized)?;
         let request = request.ok_or(ServerError::ConstructionMetadataRequestIsNil)?;
@@ -127,7 +127,7 @@ impl Asserter {
     /// [`ConstructionSubmitRequest`] is well-formatted.
     pub fn construction_submit_request(
         &self,
-        request: Option<&NullableConstructionSubmitRequest>,
+        request: Option<&UncheckedConstructionSubmitRequest>,
     ) -> AssertResult<()> {
         self.request.as_ref().ok_or(AsserterError::NotInitialized)?;
         let request = request.ok_or(ServerError::ConstructionSubmitRequestIsNil)?;
@@ -143,7 +143,7 @@ impl Asserter {
     /// [`MempoolTransactionRequest`] is well-formatted.
     pub fn mempool_transaction_request(
         &self,
-        request: Option<&NullableMempoolTransactionRequest>,
+        request: Option<&UncheckedMempoolTransactionRequest>,
     ) -> AssertResult<()> {
         self.request.as_ref().ok_or(AsserterError::NotInitialized)?;
         let request = request.ok_or(ServerError::MempoolTransactionRequestIsNil)?;
@@ -153,7 +153,7 @@ impl Asserter {
 
     /// [`metadata_request`] ensures that a [`MetadataRequest`]
     /// is well-formatted.
-    pub fn metadata_request(&self, request: Option<&NullableMetadataRequest>) -> AssertResult<()> {
+    pub fn metadata_request(&self, request: Option<&UncheckedMetadataRequest>) -> AssertResult<()> {
         self.request.as_ref().ok_or(AsserterError::NotInitialized)?;
         request.ok_or(ServerError::MetadataRequestIsNil)?;
         Ok(())
@@ -161,7 +161,7 @@ impl Asserter {
 
     /// [`network_request`] ensures that a [`NetworkRequest`]
     /// is well-formatted.
-    pub fn network_request(&self, request: Option<&NullableNetworkRequest>) -> AssertResult<()> {
+    pub fn network_request(&self, request: Option<&UncheckedNetworkRequest>) -> AssertResult<()> {
         self.request.as_ref().ok_or(AsserterError::NotInitialized)?;
         let request = request.ok_or(ServerError::NetworkRequestIsNil)?;
         self.valid_supported_network(request.network_identifier.as_ref())
@@ -171,7 +171,7 @@ impl Asserter {
     /// [`ConstructionDeriveRequest`] is well-formatted.
     pub fn construction_derive_request(
         &self,
-        request: Option<&NullableConstructionDeriveRequest>,
+        request: Option<&UncheckedConstructionDeriveRequest>,
     ) -> AssertResult<()> {
         self.request.as_ref().ok_or(AsserterError::NotInitialized)?;
         let request = request.ok_or(ServerError::ConstructionDeriveRequestIsNil)?;
@@ -183,7 +183,7 @@ impl Asserter {
     /// [`ConstructionPreprocessRequest`] is well-formatted.
     pub fn construction_preprocess_request(
         &self,
-        request: Option<&NullableConstructionPreprocessRequest>,
+        request: Option<&UncheckedConstructionPreprocessRequest>,
     ) -> AssertResult<()> {
         self.request.as_ref().ok_or(AsserterError::NotInitialized)?;
         let request = request.ok_or(ServerError::ConstructionPreprocessRequestIsNil)?;
@@ -206,7 +206,7 @@ impl Asserter {
     /// [`ConstructionPayloadsRequest`] is well-formatted.
     pub fn construction_payload_request(
         &self,
-        request: Option<&NullableConstructionPayloadsRequest>,
+        request: Option<&UncheckedConstructionPayloadsRequest>,
     ) -> AssertResult<()> {
         self.request.as_ref().ok_or(AsserterError::NotInitialized)?;
         let request = request.ok_or(ServerError::ConstructionPayloadsRequestIsNil)?;
@@ -222,7 +222,7 @@ impl Asserter {
     /// [`ConstructionCombineRequest`] is well-formatted.
     pub fn construction_combine_request(
         &self,
-        request: Option<&NullableConstructionCombineRequest>,
+        request: Option<&UncheckedConstructionCombineRequest>,
     ) -> AssertResult<()> {
         self.request.as_ref().ok_or(AsserterError::NotInitialized)?;
         let request = request.ok_or(ServerError::ConstructionCombineRequestIsNil)?;
@@ -244,7 +244,7 @@ impl Asserter {
     /// is well-formatted.
     pub fn construction_hash_request(
         &self,
-        request: Option<&NullableConstructionHashRequest>,
+        request: Option<&UncheckedConstructionHashRequest>,
     ) -> AssertResult<()> {
         self.request.as_ref().ok_or(AsserterError::NotInitialized)?;
         let request = request.ok_or(ServerError::ConstructionHashRequestIsNil)?;
@@ -260,7 +260,7 @@ impl Asserter {
     /// [`ConstructionParseRequest`] is well-formatted.
     pub fn construction_parse_request(
         &self,
-        request: Option<&NullableConstructionParseRequest>,
+        request: Option<&UncheckedConstructionParseRequest>,
     ) -> AssertResult<()> {
         self.request.as_ref().ok_or(AsserterError::NotInitialized)?;
         let request = request.ok_or(ServerError::ConstructionParseRequestIsNil)?;
@@ -290,7 +290,7 @@ impl Asserter {
 
     /// [`call_request`] ensures that a [`CallRequest`]
     /// is well-formatted.
-    pub fn call_request(&self, request: Option<&NullableCallRequest>) -> AssertResult<()> {
+    pub fn call_request(&self, request: Option<&UncheckedCallRequest>) -> AssertResult<()> {
         self.request.as_ref().ok_or(AsserterError::NotInitialized)?;
         let request = request.ok_or(ServerError::CallRequestIsNil)?;
         self.valid_supported_network(request.network_identifier.as_ref())?;
@@ -301,7 +301,7 @@ impl Asserter {
     /// is well-formatted.
     pub fn account_coins_request(
         &self,
-        request: Option<&NullableAccountCoinsRequest>,
+        request: Option<&UncheckedAccountCoinsRequest>,
     ) -> AssertResult<()> {
         let asserter = self.request.as_ref().ok_or(AsserterError::NotInitialized)?;
 
@@ -332,7 +332,7 @@ impl Asserter {
     /// is well-formatted.
     pub fn events_block_request(
         &self,
-        request: Option<&NullableEventsBlocksRequest>,
+        request: Option<&UncheckedEventsBlocksRequest>,
     ) -> AssertResult<()> {
         self.request.as_ref().ok_or(AsserterError::NotInitialized)?;
         let request = request.ok_or(ServerError::EventsBlocksRequestIsNil)?;
@@ -350,7 +350,7 @@ impl Asserter {
     /// [`SearchTransactionsRequest`] is well-formatted.
     pub fn search_transactions_request(
         &self,
-        request: Option<&NullableSearchTransactionsRequest>,
+        request: Option<&UncheckedSearchTransactionsRequest>,
     ) -> AssertResult<()> {
         self.request.as_ref().ok_or(AsserterError::NotInitialized)?;
         let request = request.ok_or(ServerError::SearchTransactionsRequestIsNil)?;

--- a/crates/mentat-asserter/src/server_test.rs
+++ b/crates/mentat-asserter/src/server_test.rs
@@ -31,15 +31,15 @@ pub(crate) const fn valid_block_index() -> isize {
     1000
 }
 
-pub(crate) fn valid_partial_block_identifier() -> NullablePartialBlockIdentifier {
-    NullablePartialBlockIdentifier {
+pub(crate) fn valid_partial_block_identifier() -> UncheckedPartialBlockIdentifier {
+    UncheckedPartialBlockIdentifier {
         index: Some(valid_block_index()),
         ..Default::default()
     }
 }
 
-pub(crate) fn valid_block_identifier() -> Option<NullableBlockIdentifier> {
-    Some(NullableBlockIdentifier {
+pub(crate) fn valid_block_identifier() -> Option<UncheckedBlockIdentifier> {
+    Some(UncheckedBlockIdentifier {
         index: valid_block_index(),
         hash: "block 1".into(),
     })
@@ -49,17 +49,17 @@ pub(crate) fn valid_transaction_identifier() -> TransactionIdentifier {
     TransactionIdentifier { hash: "tx1".into() }
 }
 
-pub(crate) fn valid_public_key() -> NullablePublicKey {
-    NullablePublicKey {
+pub(crate) fn valid_public_key() -> UncheckedPublicKey {
+    UncheckedPublicKey {
         bytes: "hello".into(),
-        curve_type: NullableCurveType::SECP256K1.into(),
+        curve_type: UncheckedCurveType::SECP256K1.into(),
     }
 }
 
-pub(crate) fn valid_amount() -> Option<NullableAmount> {
-    Some(NullableAmount {
+pub(crate) fn valid_amount() -> Option<UncheckedAmount> {
+    Some(UncheckedAmount {
         value: "1000".into(),
-        currency: Some(NullableCurrency {
+        currency: Some(UncheckedCurrency {
             symbol: "BTC".into(),
             decimals: 8,
             ..Default::default()
@@ -75,10 +75,10 @@ pub(crate) fn valid_account() -> Option<AccountIdentifier> {
     })
 }
 
-pub(crate) fn valid_ops() -> Vec<Option<NullableOperation>> {
+pub(crate) fn valid_ops() -> Vec<Option<UncheckedOperation>> {
     vec![
-        Some(NullableOperation {
-            operation_identifier: Some(NullableOperationIdentifier {
+        Some(UncheckedOperation {
+            operation_identifier: Some(UncheckedOperationIdentifier {
                 index: 0,
                 ..Default::default()
             }),
@@ -87,8 +87,8 @@ pub(crate) fn valid_ops() -> Vec<Option<NullableOperation>> {
             amount: valid_amount(),
             ..Default::default()
         }),
-        Some(NullableOperation {
-            operation_identifier: Some(NullableOperationIdentifier {
+        Some(UncheckedOperation {
+            operation_identifier: Some(UncheckedOperationIdentifier {
                 index: 1,
                 ..Default::default()
             }),
@@ -100,10 +100,10 @@ pub(crate) fn valid_ops() -> Vec<Option<NullableOperation>> {
     ]
 }
 
-pub(crate) fn unsupported_type_ops() -> Vec<Option<NullableOperation>> {
+pub(crate) fn unsupported_type_ops() -> Vec<Option<UncheckedOperation>> {
     vec![
-        Some(NullableOperation {
-            operation_identifier: Some(NullableOperationIdentifier {
+        Some(UncheckedOperation {
+            operation_identifier: Some(UncheckedOperationIdentifier {
                 index: 0,
                 ..Default::default()
             }),
@@ -112,12 +112,12 @@ pub(crate) fn unsupported_type_ops() -> Vec<Option<NullableOperation>> {
             amount: valid_amount(),
             ..Default::default()
         }),
-        Some(NullableOperation {
-            operation_identifier: Some(NullableOperationIdentifier {
+        Some(UncheckedOperation {
+            operation_identifier: Some(UncheckedOperationIdentifier {
                 index: 1,
                 ..Default::default()
             }),
-            related_operations: vec![Some(NullableOperationIdentifier {
+            related_operations: vec![Some(UncheckedOperationIdentifier {
                 index: 0,
                 ..Default::default()
             })],
@@ -129,10 +129,10 @@ pub(crate) fn unsupported_type_ops() -> Vec<Option<NullableOperation>> {
     ]
 }
 
-pub(crate) fn invalid_ops() -> Vec<Option<NullableOperation>> {
+pub(crate) fn invalid_ops() -> Vec<Option<UncheckedOperation>> {
     vec![
-        Some(NullableOperation {
-            operation_identifier: Some(NullableOperationIdentifier {
+        Some(UncheckedOperation {
+            operation_identifier: Some(UncheckedOperationIdentifier {
                 index: 0,
                 ..Default::default()
             }),
@@ -142,12 +142,12 @@ pub(crate) fn invalid_ops() -> Vec<Option<NullableOperation>> {
             amount: valid_amount(),
             ..Default::default()
         }),
-        Some(NullableOperation {
-            operation_identifier: Some(NullableOperationIdentifier {
+        Some(UncheckedOperation {
+            operation_identifier: Some(UncheckedOperationIdentifier {
                 index: 1,
                 ..Default::default()
             }),
-            related_operations: vec![Some(NullableOperationIdentifier {
+            related_operations: vec![Some(UncheckedOperationIdentifier {
                 index: 0,
                 ..Default::default()
             })],
@@ -160,57 +160,57 @@ pub(crate) fn invalid_ops() -> Vec<Option<NullableOperation>> {
     ]
 }
 
-pub(crate) fn valid_signatures() -> Vec<Option<NullableSignature>> {
-    vec![Some(NullableSignature {
-        signing_payload: Some(NullableSigningPayload {
+pub(crate) fn valid_signatures() -> Vec<Option<UncheckedSignature>> {
+    vec![Some(UncheckedSignature {
+        signing_payload: Some(UncheckedSigningPayload {
             account_identifier: valid_account(),
             bytes: "blah".into(),
             ..Default::default()
         }),
         public_key: Some(valid_public_key()),
-        signature_type: NullableSignatureType::ED25519.into(),
+        signature_type: UncheckedSignatureType::ED25519.into(),
         bytes: "hello".into(),
     })]
 }
 
-pub(crate) fn signature_type_mismatch() -> Vec<Option<NullableSignature>> {
-    vec![Some(NullableSignature {
-        signing_payload: Some(NullableSigningPayload {
+pub(crate) fn signature_type_mismatch() -> Vec<Option<UncheckedSignature>> {
+    vec![Some(UncheckedSignature {
+        signing_payload: Some(UncheckedSigningPayload {
             account_identifier: valid_account(),
             bytes: "blah".into(),
-            signature_type: NullableSignatureType::ECDSA_RECOVERY.into(),
+            signature_type: UncheckedSignatureType::ECDSA_RECOVERY.into(),
             ..Default::default()
         }),
         public_key: Some(valid_public_key()),
-        signature_type: NullableSignatureType::ED25519.into(),
+        signature_type: UncheckedSignatureType::ED25519.into(),
         bytes: "hello".into(),
     })]
 }
 
-pub(crate) fn signature_type_match() -> Vec<Option<NullableSignature>> {
-    vec![Some(NullableSignature {
-        signing_payload: Some(NullableSigningPayload {
+pub(crate) fn signature_type_match() -> Vec<Option<UncheckedSignature>> {
+    vec![Some(UncheckedSignature {
+        signing_payload: Some(UncheckedSigningPayload {
             account_identifier: valid_account(),
             bytes: "blah".into(),
-            signature_type: NullableSignatureType::ED25519.into(),
+            signature_type: UncheckedSignatureType::ED25519.into(),
             ..Default::default()
         }),
         public_key: Some(valid_public_key()),
-        signature_type: NullableSignatureType::ED25519.into(),
+        signature_type: UncheckedSignatureType::ED25519.into(),
         bytes: "hello".into(),
     })]
 }
 
-pub(crate) fn empty_signature() -> Vec<Option<NullableSignature>> {
-    vec![Some(NullableSignature {
-        signing_payload: Some(NullableSigningPayload {
+pub(crate) fn empty_signature() -> Vec<Option<UncheckedSignature>> {
+    vec![Some(UncheckedSignature {
+        signing_payload: Some(UncheckedSigningPayload {
             account_identifier: valid_account(),
             bytes: "blah".into(),
-            signature_type: NullableSignatureType::ED25519.into(),
+            signature_type: UncheckedSignatureType::ED25519.into(),
             ..Default::default()
         }),
         public_key: Some(valid_public_key()),
-        signature_type: NullableSignatureType::ED25519.into(),
+        signature_type: UncheckedSignatureType::ED25519.into(),
         ..Default::default()
     })]
 }
@@ -378,7 +378,7 @@ fn test_account_balance_request() {
             name: "valid request",
             payload: MethodPayload {
                 caller: asserter(false),
-                payload: Some(NullableAccountBalanceRequest {
+                payload: Some(UncheckedAccountBalanceRequest {
                     network_identifier: valid_network_identifier(),
                     account_identifier: valid_account_identifier(),
                     ..Default::default()
@@ -390,16 +390,16 @@ fn test_account_balance_request() {
             name: "valid request with currencies",
             payload: MethodPayload {
                 caller: asserter(false),
-                payload: Some(NullableAccountBalanceRequest {
+                payload: Some(UncheckedAccountBalanceRequest {
                     network_identifier: valid_network_identifier(),
                     account_identifier: valid_account_identifier(),
                     currencies: vec![
-                        Some(NullableCurrency {
+                        Some(UncheckedCurrency {
                             symbol: "BTC".into(),
                             decimals: 8,
                             ..Default::default()
                         }),
-                        Some(NullableCurrency {
+                        Some(UncheckedCurrency {
                             symbol: "ETH".into(),
                             decimals: 18,
                             ..Default::default()
@@ -414,16 +414,16 @@ fn test_account_balance_request() {
             name: "valid request with duplicate currencies",
             payload: MethodPayload {
                 caller: asserter(false),
-                payload: Some(NullableAccountBalanceRequest {
+                payload: Some(UncheckedAccountBalanceRequest {
                     network_identifier: valid_network_identifier(),
                     account_identifier: valid_account_identifier(),
                     currencies: vec![
-                        Some(NullableCurrency {
+                        Some(UncheckedCurrency {
                             symbol: "BTC".into(),
                             decimals: 8,
                             ..Default::default()
                         }),
-                        Some(NullableCurrency {
+                        Some(UncheckedCurrency {
                             symbol: "BTC".into(),
                             decimals: 8,
                             ..Default::default()
@@ -438,7 +438,7 @@ fn test_account_balance_request() {
             name: "invalid request wrong network",
             payload: MethodPayload {
                 caller: asserter(false),
-                payload: Some(NullableAccountBalanceRequest {
+                payload: Some(UncheckedAccountBalanceRequest {
                     network_identifier: wrong_network_identifier(),
                     account_identifier: valid_account_identifier(),
                     ..Default::default()
@@ -458,7 +458,7 @@ fn test_account_balance_request() {
             name: "missing network",
             payload: MethodPayload {
                 caller: asserter(false),
-                payload: Some(NullableAccountBalanceRequest {
+                payload: Some(UncheckedAccountBalanceRequest {
                     account_identifier: valid_account_identifier(),
                     ..Default::default()
                 }),
@@ -469,7 +469,7 @@ fn test_account_balance_request() {
             name: "missing account",
             payload: MethodPayload {
                 caller: asserter(false),
-                payload: Some(NullableAccountBalanceRequest {
+                payload: Some(UncheckedAccountBalanceRequest {
                     network_identifier: valid_network_identifier(),
                     ..Default::default()
                 }),
@@ -480,7 +480,7 @@ fn test_account_balance_request() {
             name: "valid historical request",
             payload: MethodPayload {
                 caller: asserter(true),
-                payload: Some(NullableAccountBalanceRequest {
+                payload: Some(UncheckedAccountBalanceRequest {
                     network_identifier: valid_network_identifier(),
                     account_identifier: valid_account_identifier(),
                     block_identifier: Some(valid_partial_block_identifier()),
@@ -493,10 +493,10 @@ fn test_account_balance_request() {
             name: "invalid historical request",
             payload: MethodPayload {
                 caller: asserter(true),
-                payload: Some(NullableAccountBalanceRequest {
+                payload: Some(UncheckedAccountBalanceRequest {
                     network_identifier: valid_network_identifier(),
                     account_identifier: valid_account_identifier(),
-                    block_identifier: Some(NullablePartialBlockIdentifier::default()),
+                    block_identifier: Some(UncheckedPartialBlockIdentifier::default()),
                     ..Default::default()
                 }),
             },
@@ -506,7 +506,7 @@ fn test_account_balance_request() {
             name: "valid historical request when not enabled",
             payload: MethodPayload {
                 caller: asserter(false),
-                payload: Some(NullableAccountBalanceRequest {
+                payload: Some(UncheckedAccountBalanceRequest {
                     network_identifier: valid_network_identifier(),
                     account_identifier: valid_account_identifier(),
                     block_identifier: Some(valid_partial_block_identifier()),
@@ -529,7 +529,7 @@ fn test_block_request() {
     let tests = vec![
         TestCase {
             name: "valid request",
-            payload: Some(NullableBlockRequest {
+            payload: Some(UncheckedBlockRequest {
                 network_identifier: valid_network_identifier(),
                 block_identifier: Some(valid_partial_block_identifier()),
             }),
@@ -537,9 +537,9 @@ fn test_block_request() {
         },
         TestCase {
             name: "valid request for block 0",
-            payload: Some(NullableBlockRequest {
+            payload: Some(UncheckedBlockRequest {
                 network_identifier: valid_network_identifier(),
-                block_identifier: Some(NullablePartialBlockIdentifier {
+                block_identifier: Some(UncheckedPartialBlockIdentifier {
                     index: Some(genesis_block_index()),
                     ..Default::default()
                 }),
@@ -553,7 +553,7 @@ fn test_block_request() {
         },
         TestCase {
             name: "missing network",
-            payload: Some(NullableBlockRequest {
+            payload: Some(UncheckedBlockRequest {
                 block_identifier: Some(valid_partial_block_identifier()),
                 ..Default::default()
             }),
@@ -561,7 +561,7 @@ fn test_block_request() {
         },
         TestCase {
             name: "missing block identifier",
-            payload: Some(NullableBlockRequest {
+            payload: Some(UncheckedBlockRequest {
                 network_identifier: valid_network_identifier(),
                 ..Default::default()
             }),
@@ -569,9 +569,9 @@ fn test_block_request() {
         },
         TestCase {
             name: "invalid PartialBlockIdentifier request",
-            payload: Some(NullableBlockRequest {
+            payload: Some(UncheckedBlockRequest {
                 network_identifier: valid_network_identifier(),
-                block_identifier: Some(NullablePartialBlockIdentifier::default()),
+                block_identifier: Some(UncheckedPartialBlockIdentifier::default()),
             }),
             criteria: Some(BlockError::PartialBlockIdentifierFieldsNotSet.into()),
         },
@@ -587,7 +587,7 @@ fn test_block_transaction_request() {
     let tests = vec![
         TestCase {
             name: "valid request",
-            payload: Some(NullableBlockTransactionRequest {
+            payload: Some(UncheckedBlockTransactionRequest {
                 network_identifier: valid_network_identifier(),
                 block_identifier: valid_block_identifier(),
                 transaction_identifier: Some(valid_transaction_identifier()),
@@ -596,7 +596,7 @@ fn test_block_transaction_request() {
         },
         TestCase {
             name: "invalid request wrong network",
-            payload: Some(NullableBlockTransactionRequest {
+            payload: Some(UncheckedBlockTransactionRequest {
                 network_identifier: wrong_network_identifier(),
                 block_identifier: valid_block_identifier(),
                 transaction_identifier: Some(valid_transaction_identifier()),
@@ -617,7 +617,7 @@ fn test_block_transaction_request() {
         },
         TestCase {
             name: "missing network",
-            payload: Some(NullableBlockTransactionRequest {
+            payload: Some(UncheckedBlockTransactionRequest {
                 block_identifier: valid_block_identifier(),
                 transaction_identifier: Some(valid_transaction_identifier()),
                 ..Default::default()
@@ -626,7 +626,7 @@ fn test_block_transaction_request() {
         },
         TestCase {
             name: "missing block identifier",
-            payload: Some(NullableBlockTransactionRequest {
+            payload: Some(UncheckedBlockTransactionRequest {
                 network_identifier: valid_network_identifier(),
                 transaction_identifier: Some(valid_transaction_identifier()),
                 ..Default::default()
@@ -635,9 +635,9 @@ fn test_block_transaction_request() {
         },
         TestCase {
             name: "invalid BlockIdentifier request",
-            payload: Some(NullableBlockTransactionRequest {
+            payload: Some(UncheckedBlockTransactionRequest {
                 network_identifier: valid_network_identifier(),
-                block_identifier: Some(NullableBlockIdentifier::default()),
+                block_identifier: Some(UncheckedBlockIdentifier::default()),
                 ..Default::default()
             }),
             criteria: Some(BlockError::BlockIdentifierHashMissing.into()),
@@ -654,7 +654,7 @@ fn test_construction_metadata_request() {
     let tests = vec![
         TestCase {
             name: "valid request",
-            payload: Some(NullableConstructionMetadataRequest {
+            payload: Some(UncheckedConstructionMetadataRequest {
                 network_identifier: valid_network_identifier(),
                 options: Some(Default::default()),
                 ..Default::default()
@@ -663,19 +663,19 @@ fn test_construction_metadata_request() {
         },
         TestCase {
             name: "valid request with public keys",
-            payload: Some(NullableConstructionMetadataRequest {
+            payload: Some(UncheckedConstructionMetadataRequest {
                 network_identifier: valid_network_identifier(),
                 options: Some(Default::default()),
-                public_keys: vec![Some(NullablePublicKey {
+                public_keys: vec![Some(UncheckedPublicKey {
                     bytes: "hello".into(),
-                    curve_type: NullableCurveType::SECP256K1.into(),
+                    curve_type: UncheckedCurveType::SECP256K1.into(),
                 })],
             }),
             criteria: None,
         },
         TestCase {
             name: "invalid request wrong network",
-            payload: Some(NullableConstructionMetadataRequest {
+            payload: Some(UncheckedConstructionMetadataRequest {
                 network_identifier: wrong_network_identifier(),
                 options: Some(Default::default()),
                 ..Default::default()
@@ -689,7 +689,7 @@ fn test_construction_metadata_request() {
         },
         TestCase {
             name: "missing network",
-            payload: Some(NullableConstructionMetadataRequest {
+            payload: Some(UncheckedConstructionMetadataRequest {
                 options: Some(Default::default()),
                 ..Default::default()
             }),
@@ -697,7 +697,7 @@ fn test_construction_metadata_request() {
         },
         TestCase {
             name: "missing options",
-            payload: Some(NullableConstructionMetadataRequest {
+            payload: Some(UncheckedConstructionMetadataRequest {
                 network_identifier: valid_network_identifier(),
                 options: None,
                 ..Default::default()
@@ -706,11 +706,11 @@ fn test_construction_metadata_request() {
         },
         TestCase {
             name: "invalid request with public keys",
-            payload: Some(NullableConstructionMetadataRequest {
+            payload: Some(UncheckedConstructionMetadataRequest {
                 network_identifier: valid_network_identifier(),
                 options: Some(Default::default()),
-                public_keys: vec![Some(NullablePublicKey {
-                    curve_type: NullableCurveType::SECP256K1.into(),
+                public_keys: vec![Some(UncheckedPublicKey {
+                    curve_type: UncheckedCurveType::SECP256K1.into(),
                     ..Default::default()
                 })],
             }),
@@ -730,7 +730,7 @@ fn test_construction_submit_request() {
     let tests = vec![
         TestCase {
             name: "valid request",
-            payload: Some(NullableConstructionSubmitRequest {
+            payload: Some(UncheckedConstructionSubmitRequest {
                 network_identifier: valid_network_identifier(),
                 signed_transaction: "tx".into(),
             }),
@@ -738,7 +738,7 @@ fn test_construction_submit_request() {
         },
         TestCase {
             name: "invalid request wrong network",
-            payload: Some(NullableConstructionSubmitRequest {
+            payload: Some(UncheckedConstructionSubmitRequest {
                 network_identifier: wrong_network_identifier(),
                 signed_transaction: "tx".into(),
             }),
@@ -766,7 +766,7 @@ fn test_mempool_transaction_request() {
     let tests = vec![
         TestCase {
             name: "valid request",
-            payload: Some(NullableMempoolTransactionRequest {
+            payload: Some(UncheckedMempoolTransactionRequest {
                 network_identifier: valid_network_identifier(),
                 transaction_identifier: Some(valid_transaction_identifier()),
             }),
@@ -774,7 +774,7 @@ fn test_mempool_transaction_request() {
         },
         TestCase {
             name: "invalid request wrong network",
-            payload: Some(NullableMempoolTransactionRequest {
+            payload: Some(UncheckedMempoolTransactionRequest {
                 network_identifier: wrong_network_identifier(),
                 transaction_identifier: Some(valid_transaction_identifier()),
             }),
@@ -794,7 +794,7 @@ fn test_mempool_transaction_request() {
         },
         TestCase {
             name: "missing network",
-            payload: Some(NullableMempoolTransactionRequest {
+            payload: Some(UncheckedMempoolTransactionRequest {
                 transaction_identifier: Some(valid_transaction_identifier()),
                 ..Default::default()
             }),
@@ -802,7 +802,7 @@ fn test_mempool_transaction_request() {
         },
         TestCase {
             name: "invalid TransactionIdentifier request",
-            payload: Some(NullableMempoolTransactionRequest {
+            payload: Some(UncheckedMempoolTransactionRequest {
                 network_identifier: valid_network_identifier(),
                 transaction_identifier: Some(Default::default()),
             }),
@@ -840,7 +840,7 @@ fn test_network_request() {
     let tests = vec![
         TestCase {
             name: "valid request",
-            payload: Some(NullableNetworkRequest {
+            payload: Some(UncheckedNetworkRequest {
                 network_identifier: valid_network_identifier(),
                 ..Default::default()
             }),
@@ -848,7 +848,7 @@ fn test_network_request() {
         },
         TestCase {
             name: "invalid request wrong network",
-            payload: Some(NullableNetworkRequest {
+            payload: Some(UncheckedNetworkRequest {
                 network_identifier: wrong_network_identifier(),
                 ..Default::default()
             }),
@@ -883,7 +883,7 @@ fn test_construction_derive_request() {
     let tests = vec![
         TestCase {
             name: "valid request",
-            payload: Some(NullableConstructionDeriveRequest {
+            payload: Some(UncheckedConstructionDeriveRequest {
                 network_identifier: valid_network_identifier(),
                 public_key: Some(valid_public_key()),
                 ..Default::default()
@@ -892,7 +892,7 @@ fn test_construction_derive_request() {
         },
         TestCase {
             name: "invalid request wrong network",
-            payload: Some(NullableConstructionDeriveRequest {
+            payload: Some(UncheckedConstructionDeriveRequest {
                 network_identifier: wrong_network_identifier(),
                 ..Default::default()
             }),
@@ -912,7 +912,7 @@ fn test_construction_derive_request() {
         },
         TestCase {
             name: "nil public key",
-            payload: Some(NullableConstructionDeriveRequest {
+            payload: Some(UncheckedConstructionDeriveRequest {
                 network_identifier: valid_network_identifier(),
                 ..Default::default()
             }),
@@ -920,10 +920,10 @@ fn test_construction_derive_request() {
         },
         TestCase {
             name: "empty public key bytes",
-            payload: Some(NullableConstructionDeriveRequest {
+            payload: Some(UncheckedConstructionDeriveRequest {
                 network_identifier: valid_network_identifier(),
-                public_key: Some(NullablePublicKey {
-                    curve_type: NullableCurveType::SECP256K1.into(),
+                public_key: Some(UncheckedPublicKey {
+                    curve_type: UncheckedCurveType::SECP256K1.into(),
                     ..Default::default()
                 }),
                 ..Default::default()
@@ -945,7 +945,7 @@ fn test_construction_preprocess_request() {
     let tests = vec![
         TestCase {
             name: "valid request",
-            payload: Some(NullableConstructionPreprocessRequest {
+            payload: Some(UncheckedConstructionPreprocessRequest {
                 network_identifier: valid_network_identifier(),
                 operations: valid_ops(),
                 ..Default::default()
@@ -954,7 +954,7 @@ fn test_construction_preprocess_request() {
         },
         TestCase {
             name: "valid request with suggested fee multiplier",
-            payload: Some(NullableConstructionPreprocessRequest {
+            payload: Some(UncheckedConstructionPreprocessRequest {
                 network_identifier: valid_network_identifier(),
                 operations: valid_ops(),
                 ..Default::default()
@@ -963,7 +963,7 @@ fn test_construction_preprocess_request() {
         },
         TestCase {
             name: "valid request with max fee",
-            payload: Some(NullableConstructionPreprocessRequest {
+            payload: Some(UncheckedConstructionPreprocessRequest {
                 network_identifier: valid_network_identifier(),
                 operations: valid_ops(),
                 ..Default::default()
@@ -972,7 +972,7 @@ fn test_construction_preprocess_request() {
         },
         TestCase {
             name: "valid request with suggested fee multiplier and max fee",
-            payload: Some(NullableConstructionPreprocessRequest {
+            payload: Some(UncheckedConstructionPreprocessRequest {
                 network_identifier: valid_network_identifier(),
                 operations: valid_ops(),
                 max_fee: vec![valid_amount()],
@@ -983,7 +983,7 @@ fn test_construction_preprocess_request() {
         },
         TestCase {
             name: "invalid request wrong network",
-            payload: Some(NullableConstructionPreprocessRequest {
+            payload: Some(UncheckedConstructionPreprocessRequest {
                 network_identifier: wrong_network_identifier(),
                 ..Default::default()
             }),
@@ -1003,7 +1003,7 @@ fn test_construction_preprocess_request() {
         },
         TestCase {
             name: "nil operations",
-            payload: Some(NullableConstructionPreprocessRequest {
+            payload: Some(UncheckedConstructionPreprocessRequest {
                 network_identifier: valid_network_identifier(),
                 ..Default::default()
             }),
@@ -1011,7 +1011,7 @@ fn test_construction_preprocess_request() {
         },
         TestCase {
             name: "empty operations",
-            payload: Some(NullableConstructionPreprocessRequest {
+            payload: Some(UncheckedConstructionPreprocessRequest {
                 network_identifier: valid_network_identifier(),
                 operations: Vec::new(),
                 ..Default::default()
@@ -1020,7 +1020,7 @@ fn test_construction_preprocess_request() {
         },
         TestCase {
             name: "unsupported operation type",
-            payload: Some(NullableConstructionPreprocessRequest {
+            payload: Some(UncheckedConstructionPreprocessRequest {
                 network_identifier: valid_network_identifier(),
                 operations: unsupported_type_ops(),
                 ..Default::default()
@@ -1029,7 +1029,7 @@ fn test_construction_preprocess_request() {
         },
         TestCase {
             name: "invalid operations",
-            payload: Some(NullableConstructionPreprocessRequest {
+            payload: Some(UncheckedConstructionPreprocessRequest {
                 network_identifier: valid_network_identifier(),
                 operations: invalid_ops(),
                 ..Default::default()
@@ -1038,7 +1038,7 @@ fn test_construction_preprocess_request() {
         },
         TestCase {
             name: "negative suggested fee multiplier",
-            payload: Some(NullableConstructionPreprocessRequest {
+            payload: Some(UncheckedConstructionPreprocessRequest {
                 network_identifier: valid_network_identifier(),
                 operations: valid_ops(),
                 suggested_fee_multiplier: negative_fee_multiplier,
@@ -1055,7 +1055,7 @@ fn test_construction_preprocess_request() {
         },
         TestCase {
             name: "max fee with duplicate currency",
-            payload: Some(NullableConstructionPreprocessRequest {
+            payload: Some(UncheckedConstructionPreprocessRequest {
                 network_identifier: valid_network_identifier(),
                 operations: valid_ops(),
                 max_fee: vec![valid_amount(), valid_amount()],
@@ -1083,7 +1083,7 @@ fn test_construction_payloads_request() {
     let tests = vec![
         TestCase {
             name: "valid request",
-            payload: Some(NullableConstructionPayloadsRequest {
+            payload: Some(UncheckedConstructionPayloadsRequest {
                 network_identifier: valid_network_identifier(),
                 operations: valid_ops(),
                 metadata: indexmap!("test".into() => "hello".into()),
@@ -1093,20 +1093,20 @@ fn test_construction_payloads_request() {
         },
         TestCase {
             name: "valid request with public keys",
-            payload: Some(NullableConstructionPayloadsRequest {
+            payload: Some(UncheckedConstructionPayloadsRequest {
                 network_identifier: valid_network_identifier(),
                 operations: valid_ops(),
                 metadata: indexmap!("test".into() => "hello".into()),
-                public_keys: vec![Some(NullablePublicKey {
+                public_keys: vec![Some(UncheckedPublicKey {
                     bytes: "hello".into(),
-                    curve_type: NullableCurveType::SECP256K1.into(),
+                    curve_type: UncheckedCurveType::SECP256K1.into(),
                 })],
             }),
             criteria: None,
         },
         TestCase {
             name: "invalid request wrong network",
-            payload: Some(NullableConstructionPayloadsRequest {
+            payload: Some(UncheckedConstructionPayloadsRequest {
                 network_identifier: wrong_network_identifier(),
                 ..Default::default()
             }),
@@ -1126,7 +1126,7 @@ fn test_construction_payloads_request() {
         },
         TestCase {
             name: "nil operations",
-            payload: Some(NullableConstructionPayloadsRequest {
+            payload: Some(UncheckedConstructionPayloadsRequest {
                 network_identifier: valid_network_identifier(),
                 ..Default::default()
             }),
@@ -1134,7 +1134,7 @@ fn test_construction_payloads_request() {
         },
         TestCase {
             name: "empty operations",
-            payload: Some(NullableConstructionPayloadsRequest {
+            payload: Some(UncheckedConstructionPayloadsRequest {
                 network_identifier: valid_network_identifier(),
                 operations: vec![],
                 ..Default::default()
@@ -1143,7 +1143,7 @@ fn test_construction_payloads_request() {
         },
         TestCase {
             name: "unsupported operation type",
-            payload: Some(NullableConstructionPayloadsRequest {
+            payload: Some(UncheckedConstructionPayloadsRequest {
                 network_identifier: valid_network_identifier(),
                 operations: unsupported_type_ops(),
                 ..Default::default()
@@ -1152,7 +1152,7 @@ fn test_construction_payloads_request() {
         },
         TestCase {
             name: "invalid operations",
-            payload: Some(NullableConstructionPayloadsRequest {
+            payload: Some(UncheckedConstructionPayloadsRequest {
                 network_identifier: valid_network_identifier(),
                 operations: invalid_ops(),
                 ..Default::default()
@@ -1161,12 +1161,12 @@ fn test_construction_payloads_request() {
         },
         TestCase {
             name: "invalid request with public keys",
-            payload: Some(NullableConstructionPayloadsRequest {
+            payload: Some(UncheckedConstructionPayloadsRequest {
                 network_identifier: valid_network_identifier(),
                 operations: valid_ops(),
                 metadata: indexmap!("test".into() => "hello".into()),
-                public_keys: vec![Some(NullablePublicKey {
-                    curve_type: NullableCurveType::SECP256K1.into(),
+                public_keys: vec![Some(UncheckedPublicKey {
+                    curve_type: UncheckedCurveType::SECP256K1.into(),
                     ..Default::default()
                 })],
             }),
@@ -1184,7 +1184,7 @@ fn test_construction_combine_request() {
     let tests = vec![
         TestCase {
             name: "valid request",
-            payload: Some(NullableConstructionCombineRequest {
+            payload: Some(UncheckedConstructionCombineRequest {
                 network_identifier: valid_network_identifier(),
                 unsigned_transaction: "blah".into(),
                 signatures: valid_signatures(),
@@ -1193,17 +1193,17 @@ fn test_construction_combine_request() {
         },
         TestCase {
             name: "valid request 2",
-            payload: Some(NullableConstructionCombineRequest {
+            payload: Some(UncheckedConstructionCombineRequest {
                 network_identifier: valid_network_identifier(),
                 unsigned_transaction: "blah".into(),
-                signatures: vec![Some(NullableSignature {
-                    signing_payload: Some(NullableSigningPayload {
+                signatures: vec![Some(UncheckedSignature {
+                    signing_payload: Some(UncheckedSigningPayload {
                         account_identifier: valid_account(),
                         bytes: "blah".into(),
                         ..Default::default()
                     }),
                     public_key: Some(valid_public_key()),
-                    signature_type: NullableSignatureType::ED25519.into(),
+                    signature_type: UncheckedSignatureType::ED25519.into(),
                     bytes: "blah".into(),
                 })],
             }),
@@ -1211,17 +1211,17 @@ fn test_construction_combine_request() {
         },
         TestCase {
             name: "valid request 3",
-            payload: Some(NullableConstructionCombineRequest {
+            payload: Some(UncheckedConstructionCombineRequest {
                 network_identifier: valid_network_identifier(),
                 unsigned_transaction: "blah".into(),
-                signatures: vec![Some(NullableSignature {
-                    signing_payload: Some(NullableSigningPayload {
+                signatures: vec![Some(UncheckedSignature {
+                    signing_payload: Some(UncheckedSigningPayload {
                         account_identifier: valid_account(),
                         bytes: "blah".into(),
                         ..Default::default()
                     }),
                     public_key: Some(valid_public_key()),
-                    signature_type: NullableSignatureType::ED25519.into(),
+                    signature_type: UncheckedSignatureType::ED25519.into(),
                     bytes: "hello".into(),
                 })],
             }),
@@ -1229,7 +1229,7 @@ fn test_construction_combine_request() {
         },
         TestCase {
             name: "invalid request wrong network",
-            payload: Some(NullableConstructionCombineRequest {
+            payload: Some(UncheckedConstructionCombineRequest {
                 network_identifier: wrong_network_identifier(),
                 ..Default::default()
             }),
@@ -1249,7 +1249,7 @@ fn test_construction_combine_request() {
         },
         TestCase {
             name: "empty unsigned transaction",
-            payload: Some(NullableConstructionCombineRequest {
+            payload: Some(UncheckedConstructionCombineRequest {
                 network_identifier: valid_network_identifier(),
                 signatures: valid_signatures(),
                 ..Default::default()
@@ -1258,7 +1258,7 @@ fn test_construction_combine_request() {
         },
         TestCase {
             name: "nil signatures",
-            payload: Some(NullableConstructionCombineRequest {
+            payload: Some(UncheckedConstructionCombineRequest {
                 network_identifier: valid_network_identifier(),
                 unsigned_transaction: "blah".into(),
                 ..Default::default()
@@ -1267,7 +1267,7 @@ fn test_construction_combine_request() {
         },
         TestCase {
             name: "empty signatures",
-            payload: Some(NullableConstructionCombineRequest {
+            payload: Some(UncheckedConstructionCombineRequest {
                 network_identifier: valid_network_identifier(),
                 unsigned_transaction: "blah".into(),
                 signatures: vec![],
@@ -1276,7 +1276,7 @@ fn test_construction_combine_request() {
         },
         TestCase {
             name: "signature type mismatch",
-            payload: Some(NullableConstructionCombineRequest {
+            payload: Some(UncheckedConstructionCombineRequest {
                 network_identifier: valid_network_identifier(),
                 unsigned_transaction: "blah".into(),
                 signatures: signature_type_mismatch(),
@@ -1285,7 +1285,7 @@ fn test_construction_combine_request() {
         },
         TestCase {
             name: "empty signature",
-            payload: Some(NullableConstructionCombineRequest {
+            payload: Some(UncheckedConstructionCombineRequest {
                 network_identifier: valid_network_identifier(),
                 unsigned_transaction: "blah".into(),
                 signatures: empty_signature(),
@@ -1294,7 +1294,7 @@ fn test_construction_combine_request() {
         },
         TestCase {
             name: "signature type match",
-            payload: Some(NullableConstructionCombineRequest {
+            payload: Some(UncheckedConstructionCombineRequest {
                 network_identifier: valid_network_identifier(),
                 unsigned_transaction: "blah".into(),
                 signatures: signature_type_match(),
@@ -1313,7 +1313,7 @@ fn test_construction_hash_request() {
     let tests = vec![
         TestCase {
             name: "valid request",
-            payload: Some(NullableConstructionHashRequest {
+            payload: Some(UncheckedConstructionHashRequest {
                 network_identifier: valid_network_identifier(),
                 signed_transaction: "blah".into(),
             }),
@@ -1321,7 +1321,7 @@ fn test_construction_hash_request() {
         },
         TestCase {
             name: "invalid request wrong network",
-            payload: Some(NullableConstructionHashRequest {
+            payload: Some(UncheckedConstructionHashRequest {
                 network_identifier: wrong_network_identifier(),
                 ..Default::default()
             }),
@@ -1341,7 +1341,7 @@ fn test_construction_hash_request() {
         },
         TestCase {
             name: "empty signed transaction",
-            payload: Some(NullableConstructionHashRequest {
+            payload: Some(UncheckedConstructionHashRequest {
                 network_identifier: valid_network_identifier(),
                 ..Default::default()
             }),
@@ -1359,7 +1359,7 @@ fn test_construction_parse_request() {
     let tests = vec![
         TestCase {
             name: "valid request",
-            payload: Some(NullableConstructionParseRequest {
+            payload: Some(UncheckedConstructionParseRequest {
                 network_identifier: valid_network_identifier(),
                 transaction: "blah".into(),
                 ..Default::default()
@@ -1368,7 +1368,7 @@ fn test_construction_parse_request() {
         },
         TestCase {
             name: "invalid request wrong network",
-            payload: Some(NullableConstructionParseRequest {
+            payload: Some(UncheckedConstructionParseRequest {
                 network_identifier: wrong_network_identifier(),
                 ..Default::default()
             }),
@@ -1381,7 +1381,7 @@ fn test_construction_parse_request() {
         },
         TestCase {
             name: "empty signed transaction",
-            payload: Some(NullableConstructionParseRequest {
+            payload: Some(UncheckedConstructionParseRequest {
                 network_identifier: valid_network_identifier(),
                 ..Default::default()
             }),
@@ -1399,7 +1399,7 @@ fn test_call_request() {
     let tests = vec![
         TestCase {
             name: "valid request",
-            payload: Some(NullableCallRequest {
+            payload: Some(UncheckedCallRequest {
                 network_identifier: valid_network_identifier(),
                 method: "eth_call".into(),
                 ..Default::default()
@@ -1408,7 +1408,7 @@ fn test_call_request() {
         },
         TestCase {
             name: "valid request with params",
-            payload: Some(NullableCallRequest {
+            payload: Some(UncheckedCallRequest {
                 network_identifier: valid_network_identifier(),
                 method: "eth_call".into(),
                 parameters: indexmap!("hello".into() => "test".into()),
@@ -1417,7 +1417,7 @@ fn test_call_request() {
         },
         TestCase {
             name: "invalid request wrong network",
-            payload: Some(NullableCallRequest {
+            payload: Some(UncheckedCallRequest {
                 network_identifier: wrong_network_identifier(),
                 ..Default::default()
             }),
@@ -1432,7 +1432,7 @@ fn test_call_request() {
         },
         TestCase {
             name: "unsupported method",
-            payload: Some(NullableCallRequest {
+            payload: Some(UncheckedCallRequest {
                 network_identifier: valid_network_identifier(),
                 method: "eth_debug".into(),
                 ..Default::default()
@@ -1446,7 +1446,7 @@ fn test_call_request() {
         },
         TestCase {
             name: "empty method",
-            payload: Some(NullableCallRequest {
+            payload: Some(UncheckedCallRequest {
                 network_identifier: valid_network_identifier(),
                 ..Default::default()
             }),
@@ -1478,7 +1478,7 @@ fn test_account_coins_request() {
             name: "valid request",
             payload: MethodPayload {
                 caller: asserter(false),
-                payload: Some(NullableAccountCoinsRequest {
+                payload: Some(UncheckedAccountCoinsRequest {
                     network_identifier: valid_network_identifier(),
                     account_identifier: valid_account_identifier(),
                     ..Default::default()
@@ -1490,16 +1490,16 @@ fn test_account_coins_request() {
             name: "valid request with currencies",
             payload: MethodPayload {
                 caller: asserter(false),
-                payload: Some(NullableAccountCoinsRequest {
+                payload: Some(UncheckedAccountCoinsRequest {
                     network_identifier: valid_network_identifier(),
                     account_identifier: valid_account_identifier(),
                     currencies: vec![
-                        Some(NullableCurrency {
+                        Some(UncheckedCurrency {
                             symbol: "BTC".into(),
                             decimals: 8,
                             ..Default::default()
                         }),
-                        Some(NullableCurrency {
+                        Some(UncheckedCurrency {
                             symbol: "ETH".into(),
                             decimals: 18,
                             ..Default::default()
@@ -1514,11 +1514,11 @@ fn test_account_coins_request() {
             name: "valid request with duplicate currencies",
             payload: MethodPayload {
                 caller: asserter(false),
-                payload: Some(NullableAccountCoinsRequest {
+                payload: Some(UncheckedAccountCoinsRequest {
                     network_identifier: valid_network_identifier(),
                     account_identifier: valid_account_identifier(),
                     currencies: vec![
-                        Some(NullableCurrency {
+                        Some(UncheckedCurrency {
                             symbol: "BTC".into(),
                             decimals: 8,
                             ..Default::default()
@@ -1534,7 +1534,7 @@ fn test_account_coins_request() {
             name: "invalid request wrong network",
             payload: MethodPayload {
                 caller: asserter(false),
-                payload: Some(NullableAccountCoinsRequest {
+                payload: Some(UncheckedAccountCoinsRequest {
                     network_identifier: wrong_network_identifier(),
                     account_identifier: valid_account_identifier(),
                     ..Default::default()
@@ -1554,7 +1554,7 @@ fn test_account_coins_request() {
             name: "missing network",
             payload: MethodPayload {
                 caller: asserter(false),
-                payload: Some(NullableAccountCoinsRequest {
+                payload: Some(UncheckedAccountCoinsRequest {
                     account_identifier: valid_account_identifier(),
                     ..Default::default()
                 }),
@@ -1565,7 +1565,7 @@ fn test_account_coins_request() {
             name: "missing account",
             payload: MethodPayload {
                 caller: asserter(false),
-                payload: Some(NullableAccountCoinsRequest {
+                payload: Some(UncheckedAccountCoinsRequest {
                     network_identifier: valid_network_identifier(),
                     ..Default::default()
                 }),
@@ -1576,7 +1576,7 @@ fn test_account_coins_request() {
             name: "valid mempool lookup request",
             payload: MethodPayload {
                 caller: asserter(true),
-                payload: Some(NullableAccountCoinsRequest {
+                payload: Some(UncheckedAccountCoinsRequest {
                     network_identifier: valid_network_identifier(),
                     account_identifier: valid_account_identifier(),
                     ..Default::default()
@@ -1588,7 +1588,7 @@ fn test_account_coins_request() {
             name: "valid mempool lookup request when not enabled",
             payload: MethodPayload {
                 caller: asserter(false),
-                payload: Some(NullableAccountCoinsRequest {
+                payload: Some(UncheckedAccountCoinsRequest {
                     network_identifier: valid_network_identifier(),
                     account_identifier: valid_account_identifier(),
                     include_mempool: true,
@@ -1609,7 +1609,7 @@ fn test_event_blocks_request() {
     let tests = vec![
         TestCase {
             name: "valid request",
-            payload: Some(NullableEventsBlocksRequest {
+            payload: Some(UncheckedEventsBlocksRequest {
                 network_identifier: valid_network_identifier(),
                 ..Default::default()
             }),
@@ -1617,7 +1617,7 @@ fn test_event_blocks_request() {
         },
         TestCase {
             name: "invalid request wrong network",
-            payload: Some(NullableEventsBlocksRequest {
+            payload: Some(UncheckedEventsBlocksRequest {
                 network_identifier: wrong_network_identifier(),
                 ..Default::default()
             }),
@@ -1637,7 +1637,7 @@ fn test_event_blocks_request() {
         },
         TestCase {
             name: "negative offset",
-            payload: Some(NullableEventsBlocksRequest {
+            payload: Some(UncheckedEventsBlocksRequest {
                 network_identifier: valid_network_identifier(),
                 offset: Some(-1),
                 ..Default::default()
@@ -1646,7 +1646,7 @@ fn test_event_blocks_request() {
         },
         TestCase {
             name: "negative limit",
-            payload: Some(NullableEventsBlocksRequest {
+            payload: Some(UncheckedEventsBlocksRequest {
                 network_identifier: valid_network_identifier(),
                 limit: Some(-1),
                 ..Default::default()
@@ -1665,7 +1665,7 @@ fn test_search_transactions_request() {
     let tests = vec![
         TestCase {
             name: "valid request no operator",
-            payload: Some(NullableSearchTransactionsRequest {
+            payload: Some(UncheckedSearchTransactionsRequest {
                 network_identifier: valid_network_identifier(),
                 ..Default::default()
             }),
@@ -1673,18 +1673,18 @@ fn test_search_transactions_request() {
         },
         TestCase {
             name: "valid request",
-            payload: Some(NullableSearchTransactionsRequest {
+            payload: Some(UncheckedSearchTransactionsRequest {
                 network_identifier: valid_network_identifier(),
-                operator: Some(NullableOperator::AND.into()),
+                operator: Some(UncheckedOperator::AND.into()),
                 ..Default::default()
             }),
             criteria: None,
         },
         TestCase {
             name: "invalid request wrong network",
-            payload: Some(NullableSearchTransactionsRequest {
+            payload: Some(UncheckedSearchTransactionsRequest {
                 network_identifier: wrong_network_identifier(),
-                operator: Some(NullableOperator::OR.into()),
+                operator: Some(UncheckedOperator::OR.into()),
                 ..Default::default()
             }),
             criteria: Some(
@@ -1703,9 +1703,9 @@ fn test_search_transactions_request() {
         },
         TestCase {
             name: "negative max block",
-            payload: Some(NullableSearchTransactionsRequest {
+            payload: Some(UncheckedSearchTransactionsRequest {
                 network_identifier: valid_network_identifier(),
-                operator: Some(NullableOperator::OR.into()),
+                operator: Some(UncheckedOperator::OR.into()),
                 max_block: Some(-1),
                 ..Default::default()
             }),
@@ -1713,9 +1713,9 @@ fn test_search_transactions_request() {
         },
         TestCase {
             name: "negative offset",
-            payload: Some(NullableSearchTransactionsRequest {
+            payload: Some(UncheckedSearchTransactionsRequest {
                 network_identifier: valid_network_identifier(),
-                operator: Some(NullableOperator::OR.into()),
+                operator: Some(UncheckedOperator::OR.into()),
                 offset: Some(-1),
                 ..Default::default()
             }),
@@ -1723,9 +1723,9 @@ fn test_search_transactions_request() {
         },
         TestCase {
             name: "negative limit",
-            payload: Some(NullableSearchTransactionsRequest {
+            payload: Some(UncheckedSearchTransactionsRequest {
                 network_identifier: valid_network_identifier(),
-                operator: Some(NullableOperator::OR.into()),
+                operator: Some(UncheckedOperator::OR.into()),
                 limit: Some(-1),
                 ..Default::default()
             }),
@@ -1733,7 +1733,7 @@ fn test_search_transactions_request() {
         },
         TestCase {
             name: "invalid operator",
-            payload: Some(NullableSearchTransactionsRequest {
+            payload: Some(UncheckedSearchTransactionsRequest {
                 network_identifier: valid_network_identifier(),
                 operator: Some("nor".into()),
                 ..Default::default()

--- a/crates/mentat-asserter/src/server_test.rs
+++ b/crates/mentat-asserter/src/server_test.rs
@@ -23,23 +23,23 @@ pub(crate) fn valid_account_identifier() -> Option<AccountIdentifier> {
     })
 }
 
-pub(crate) const fn genesis_block_index() -> i64 {
+pub(crate) const fn genesis_block_index() -> isize {
     0
 }
 
-pub(crate) const fn valid_block_index() -> i64 {
+pub(crate) const fn valid_block_index() -> isize {
     1000
 }
 
-pub(crate) fn valid_partial_block_identifier() -> PartialBlockIdentifier {
-    PartialBlockIdentifier {
+pub(crate) fn valid_partial_block_identifier() -> NullablePartialBlockIdentifier {
+    NullablePartialBlockIdentifier {
         index: Some(valid_block_index()),
         ..Default::default()
     }
 }
 
-pub(crate) fn valid_block_identifier() -> Option<BlockIdentifier> {
-    Some(BlockIdentifier {
+pub(crate) fn valid_block_identifier() -> Option<NullableBlockIdentifier> {
+    Some(NullableBlockIdentifier {
         index: valid_block_index(),
         hash: "block 1".into(),
     })
@@ -78,7 +78,7 @@ pub(crate) fn valid_account() -> Option<AccountIdentifier> {
 pub(crate) fn valid_ops() -> Vec<Option<NullableOperation>> {
     vec![
         Some(NullableOperation {
-            operation_identifier: Some(OperationIdentifier {
+            operation_identifier: Some(NullableOperationIdentifier {
                 index: 0,
                 ..Default::default()
             }),
@@ -88,7 +88,7 @@ pub(crate) fn valid_ops() -> Vec<Option<NullableOperation>> {
             ..Default::default()
         }),
         Some(NullableOperation {
-            operation_identifier: Some(OperationIdentifier {
+            operation_identifier: Some(NullableOperationIdentifier {
                 index: 1,
                 ..Default::default()
             }),
@@ -103,7 +103,7 @@ pub(crate) fn valid_ops() -> Vec<Option<NullableOperation>> {
 pub(crate) fn unsupported_type_ops() -> Vec<Option<NullableOperation>> {
     vec![
         Some(NullableOperation {
-            operation_identifier: Some(OperationIdentifier {
+            operation_identifier: Some(NullableOperationIdentifier {
                 index: 0,
                 ..Default::default()
             }),
@@ -113,11 +113,11 @@ pub(crate) fn unsupported_type_ops() -> Vec<Option<NullableOperation>> {
             ..Default::default()
         }),
         Some(NullableOperation {
-            operation_identifier: Some(OperationIdentifier {
+            operation_identifier: Some(NullableOperationIdentifier {
                 index: 1,
                 ..Default::default()
             }),
-            related_operations: vec![Some(OperationIdentifier {
+            related_operations: vec![Some(NullableOperationIdentifier {
                 index: 0,
                 ..Default::default()
             })],
@@ -132,7 +132,7 @@ pub(crate) fn unsupported_type_ops() -> Vec<Option<NullableOperation>> {
 pub(crate) fn invalid_ops() -> Vec<Option<NullableOperation>> {
     vec![
         Some(NullableOperation {
-            operation_identifier: Some(OperationIdentifier {
+            operation_identifier: Some(NullableOperationIdentifier {
                 index: 0,
                 ..Default::default()
             }),
@@ -143,11 +143,11 @@ pub(crate) fn invalid_ops() -> Vec<Option<NullableOperation>> {
             ..Default::default()
         }),
         Some(NullableOperation {
-            operation_identifier: Some(OperationIdentifier {
+            operation_identifier: Some(NullableOperationIdentifier {
                 index: 1,
                 ..Default::default()
             }),
-            related_operations: vec![Some(OperationIdentifier {
+            related_operations: vec![Some(NullableOperationIdentifier {
                 index: 0,
                 ..Default::default()
             })],
@@ -496,7 +496,7 @@ fn test_account_balance_request() {
                 payload: Some(NullableAccountBalanceRequest {
                     network_identifier: valid_network_identifier(),
                     account_identifier: valid_account_identifier(),
-                    block_identifier: Some(PartialBlockIdentifier::default()),
+                    block_identifier: Some(NullablePartialBlockIdentifier::default()),
                     ..Default::default()
                 }),
             },
@@ -539,7 +539,7 @@ fn test_block_request() {
             name: "valid request for block 0",
             payload: Some(NullableBlockRequest {
                 network_identifier: valid_network_identifier(),
-                block_identifier: Some(PartialBlockIdentifier {
+                block_identifier: Some(NullablePartialBlockIdentifier {
                     index: Some(genesis_block_index()),
                     ..Default::default()
                 }),
@@ -571,7 +571,7 @@ fn test_block_request() {
             name: "invalid PartialBlockIdentifier request",
             payload: Some(NullableBlockRequest {
                 network_identifier: valid_network_identifier(),
-                block_identifier: Some(PartialBlockIdentifier::default()),
+                block_identifier: Some(NullablePartialBlockIdentifier::default()),
             }),
             criteria: Some(BlockError::PartialBlockIdentifierFieldsNotSet.into()),
         },
@@ -637,7 +637,7 @@ fn test_block_transaction_request() {
             name: "invalid BlockIdentifier request",
             payload: Some(NullableBlockTransactionRequest {
                 network_identifier: valid_network_identifier(),
-                block_identifier: Some(BlockIdentifier::default()),
+                block_identifier: Some(NullableBlockIdentifier::default()),
                 ..Default::default()
             }),
             criteria: Some(BlockError::BlockIdentifierHashMissing.into()),

--- a/crates/mentat-client/src/lib.rs
+++ b/crates/mentat-client/src/lib.rs
@@ -87,60 +87,60 @@ impl Client {
     /// Make a call to the /network/list Rosetta API endpoint.
     pub async fn network_list(
         &self,
-        request: NullableMetadataRequest,
-    ) -> Result<NullableNetworkListResponse> {
-        let resp: NullableNetworkListResponse = self.post("network/list", &request).await?;
+        request: UncheckedMetadataRequest,
+    ) -> Result<UncheckedNetworkListResponse> {
+        let resp: UncheckedNetworkListResponse = self.post("network/list", &request).await?;
         Ok(resp)
     }
 
     /// Make a call to the /network/options Rosetta API endpoint.
     pub async fn network_options(
         &self,
-        request: NullableNetworkRequest,
-    ) -> Result<NullableNetworkOptionsResponse> {
-        let resp: NullableNetworkOptionsResponse = self.post("network/options", &request).await?;
+        request: UncheckedNetworkRequest,
+    ) -> Result<UncheckedNetworkOptionsResponse> {
+        let resp: UncheckedNetworkOptionsResponse = self.post("network/options", &request).await?;
         Ok(resp)
     }
 
     /// Make a call to the /network/status Rosetta API endpoint.
     pub async fn network_status(
         &self,
-        request: NullableNetworkRequest,
-    ) -> Result<NullableNetworkStatusResponse> {
-        let resp: NullableNetworkStatusResponse = self.post("network/status", &request).await?;
+        request: UncheckedNetworkRequest,
+    ) -> Result<UncheckedNetworkStatusResponse> {
+        let resp: UncheckedNetworkStatusResponse = self.post("network/status", &request).await?;
         Ok(resp)
     }
 
     /// Make a call to the /account/balance Rosetta API endpoint.
     pub async fn account_balance(
         &self,
-        request: NullableAccountBalanceRequest,
-    ) -> Result<NullableAccountBalanceResponse> {
-        let resp: NullableAccountBalanceResponse = self.post("account/balance", &request).await?;
+        request: UncheckedAccountBalanceRequest,
+    ) -> Result<UncheckedAccountBalanceResponse> {
+        let resp: UncheckedAccountBalanceResponse = self.post("account/balance", &request).await?;
         Ok(resp)
     }
 
     /// Make a call to the /account/coins Rosetta API endpoint.
     pub async fn account_coins(
         &self,
-        request: NullableAccountCoinsRequest,
-    ) -> Result<NullableAccountCoinsResponse> {
-        let resp: NullableAccountCoinsResponse = self.post("account/coins", &request).await?;
+        request: UncheckedAccountCoinsRequest,
+    ) -> Result<UncheckedAccountCoinsResponse> {
+        let resp: UncheckedAccountCoinsResponse = self.post("account/coins", &request).await?;
         Ok(resp)
     }
 
     /// Make a call to the /block Rosetta API endpoint.
-    pub async fn block(&self, request: NullableBlockRequest) -> Result<NullableBlockResponse> {
-        let resp: NullableBlockResponse = self.post("block", &request).await?;
+    pub async fn block(&self, request: UncheckedBlockRequest) -> Result<UncheckedBlockResponse> {
+        let resp: UncheckedBlockResponse = self.post("block", &request).await?;
         Ok(resp)
     }
 
     /// Make a call to the /block/transaction Rosetta API endpoint.
     pub async fn block_transaction(
         &self,
-        request: NullableBlockTransactionRequest,
-    ) -> Result<NullableBlockTransactionResponse> {
-        let resp: NullableBlockTransactionResponse =
+        request: UncheckedBlockTransactionRequest,
+    ) -> Result<UncheckedBlockTransactionResponse> {
+        let resp: UncheckedBlockTransactionResponse =
             self.post("block/transaction", &request).await?;
         Ok(resp)
     }
@@ -148,18 +148,18 @@ impl Client {
     /// Make a call to the /mempool Rosetta API endpoint.
     pub async fn mempool(
         &self,
-        request: NullableNetworkRequest,
-    ) -> Result<NullableMempoolResponse> {
-        let resp: NullableMempoolResponse = self.post("mempool", &request).await?;
+        request: UncheckedNetworkRequest,
+    ) -> Result<UncheckedMempoolResponse> {
+        let resp: UncheckedMempoolResponse = self.post("mempool", &request).await?;
         Ok(resp)
     }
 
     /// Make a call to the /mempool/transaction Rosetta API endpoint.
     pub async fn mempool_transaction(
         &self,
-        request: NullableMempoolTransactionRequest,
-    ) -> Result<NullableMempoolTransactionResponse> {
-        let resp: NullableMempoolTransactionResponse =
+        request: UncheckedMempoolTransactionRequest,
+    ) -> Result<UncheckedMempoolTransactionResponse> {
+        let resp: UncheckedMempoolTransactionResponse =
             self.post("mempool/transaction", &request).await?;
         Ok(resp)
     }
@@ -167,9 +167,9 @@ impl Client {
     /// Make a call to the /construction/combine Rosetta API endpoint.
     pub async fn construction_combine(
         &self,
-        request: NullableConstructionCombineRequest,
-    ) -> Result<NullableConstructionCombineResponse> {
-        let resp: NullableConstructionCombineResponse =
+        request: UncheckedConstructionCombineRequest,
+    ) -> Result<UncheckedConstructionCombineResponse> {
+        let resp: UncheckedConstructionCombineResponse =
             self.post("construction/combine", &request).await?;
         Ok(resp)
     }
@@ -177,9 +177,9 @@ impl Client {
     /// Make a call to the /construction/derive Rosetta API endpoint.
     pub async fn construction_derive(
         &self,
-        request: NullableConstructionDeriveRequest,
-    ) -> Result<NullableConstructionDeriveResponse> {
-        let resp: NullableConstructionDeriveResponse =
+        request: UncheckedConstructionDeriveRequest,
+    ) -> Result<UncheckedConstructionDeriveResponse> {
+        let resp: UncheckedConstructionDeriveResponse =
             self.post("construction/derive", &request).await?;
         Ok(resp)
     }
@@ -187,9 +187,9 @@ impl Client {
     /// Make a call to the /construction/hash Rosetta API endpoint.
     pub async fn construction_hash(
         &self,
-        request: NullableConstructionHashRequest,
-    ) -> Result<NullableTransactionIdentifierResponse> {
-        let resp: NullableTransactionIdentifierResponse =
+        request: UncheckedConstructionHashRequest,
+    ) -> Result<UncheckedTransactionIdentifierResponse> {
+        let resp: UncheckedTransactionIdentifierResponse =
             self.post("construction/hash", &request).await?;
         Ok(resp)
     }
@@ -197,9 +197,9 @@ impl Client {
     /// Make a call to the /construction/metadata Rosetta API endpoint.
     pub async fn construction_metadata(
         &self,
-        request: NullableConstructionMetadataRequest,
+        request: UncheckedConstructionMetadataRequest,
     ) -> Result<ConstructionMetadataResponse> {
-        let resp: NullableConstructionMetadataResponse =
+        let resp: UncheckedConstructionMetadataResponse =
             self.post("construction/metadata", &request).await?;
         Ok(resp.into())
     }
@@ -207,9 +207,9 @@ impl Client {
     /// Make a call to the /construction/parse Rosetta API endpoint.
     pub async fn construction_parse(
         &self,
-        request: NullableConstructionParseRequest,
-    ) -> Result<NullableConstructionParseResponse> {
-        let resp: NullableConstructionParseResponse =
+        request: UncheckedConstructionParseRequest,
+    ) -> Result<UncheckedConstructionParseResponse> {
+        let resp: UncheckedConstructionParseResponse =
             self.post("construction/parse", &request).await?;
         Ok(resp)
     }
@@ -217,9 +217,9 @@ impl Client {
     /// Make a call to the /construction/payloads Rosetta API endpoint.
     pub async fn construction_payloads(
         &self,
-        request: NullableConstructionPayloadsRequest,
-    ) -> Result<NullableConstructionPayloadsResponse> {
-        let resp: NullableConstructionPayloadsResponse =
+        request: UncheckedConstructionPayloadsRequest,
+    ) -> Result<UncheckedConstructionPayloadsResponse> {
+        let resp: UncheckedConstructionPayloadsResponse =
             self.post("construction/payloads", &request).await?;
         Ok(resp)
     }
@@ -227,9 +227,9 @@ impl Client {
     /// Make a call to the /construction/preprocess Rosetta API endpoint.
     pub async fn construction_preprocess(
         &self,
-        request: NullableConstructionPreprocessRequest,
-    ) -> Result<NullableConstructionPreprocessResponse> {
-        let resp: NullableConstructionPreprocessResponse =
+        request: UncheckedConstructionPreprocessRequest,
+    ) -> Result<UncheckedConstructionPreprocessResponse> {
+        let resp: UncheckedConstructionPreprocessResponse =
             self.post("construction/preprocess", &request).await?;
         Ok(resp)
     }
@@ -237,9 +237,9 @@ impl Client {
     /// Make a call to the /construction/submit Rosetta API endpoint.
     pub async fn construction_submit(
         &self,
-        request: NullableConstructionSubmitRequest,
-    ) -> Result<NullableTransactionIdentifierResponse> {
-        let resp: NullableTransactionIdentifierResponse =
+        request: UncheckedConstructionSubmitRequest,
+    ) -> Result<UncheckedTransactionIdentifierResponse> {
+        let resp: UncheckedTransactionIdentifierResponse =
             self.post("construction/submit", &request).await?;
         Ok(resp)
     }
@@ -247,18 +247,18 @@ impl Client {
     /// Make a call to the /events/blocks Rosetta API endpoint.
     pub async fn events_blocks(
         &self,
-        request: NullableEventsBlocksRequest,
-    ) -> Result<NullableEventsBlocksResponse> {
-        let resp: NullableEventsBlocksResponse = self.post("events/blocks", &request).await?;
+        request: UncheckedEventsBlocksRequest,
+    ) -> Result<UncheckedEventsBlocksResponse> {
+        let resp: UncheckedEventsBlocksResponse = self.post("events/blocks", &request).await?;
         Ok(resp)
     }
 
     /// Make a call to the /search/transactions Rosetta API endpoint.
     pub async fn search_transactions(
         &self,
-        request: NullableSearchTransactionsRequest,
-    ) -> Result<NullableSearchTransactionsResponse> {
-        let resp: NullableSearchTransactionsResponse =
+        request: UncheckedSearchTransactionsRequest,
+    ) -> Result<UncheckedSearchTransactionsResponse> {
+        let resp: UncheckedSearchTransactionsResponse =
             self.post("search/transactions", &request).await?;
         Ok(resp)
     }

--- a/crates/mentat-parser/src/balance_changes_test.rs
+++ b/crates/mentat-parser/src/balance_changes_test.rs
@@ -7,10 +7,10 @@ pub fn simple_asserter_configuration(
         Asserter::new_client_with_options(
             Some(NetworkIdentifier {
                 blockchain: "bitcoin".to_string(),
-                network: "mainnent".to_string(),
+                network: "mainnet".to_string(),
                 ..Default::default()
             }),
-            Some(BlockIdentifier {
+            Some(NullableBlockIdentifier {
                 hash: "block 0".to_string(),
                 index: 0,
             }),
@@ -162,7 +162,7 @@ fn test_balance_changes() {
                             index: 0,
                         },
                         transactions: vec![recipient_transaction.clone()],
-                        timestamp: MIN_UNIX_EPOCH + 1,
+                        timestamp: MIN_UNIX_EPOCH as usize + 1,
                         ..Default::default()
                     },
                     orphan: false,
@@ -198,7 +198,7 @@ fn test_balance_changes() {
                             index: 0,
                         },
                         transactions: vec![recipient_transaction],
-                        timestamp: MIN_UNIX_EPOCH + 1,
+                        timestamp: MIN_UNIX_EPOCH as usize + 1,
                         ..Default::default()
                     },
                     orphan: false,
@@ -225,7 +225,7 @@ fn test_balance_changes() {
                             simple_transaction_factory("tx2", "addr1", "150", currency.clone()),
                             simple_transaction_factory("tx3", "addr2", "150", currency.clone()),
                         ],
-                        timestamp: MIN_UNIX_EPOCH + 1,
+                        timestamp: MIN_UNIX_EPOCH as usize + 1,
                         ..Default::default()
                     },
                     orphan: false,
@@ -277,7 +277,7 @@ fn test_balance_changes() {
                             simple_transaction_factory("tx2", "addr1", "150", currency.clone()),
                             simple_transaction_factory("tx3", "addr2", "150", currency.clone()),
                         ],
-                        timestamp: MIN_UNIX_EPOCH + 1,
+                        timestamp: MIN_UNIX_EPOCH as usize + 1,
                         ..Default::default()
                     },
                     orphan: true,

--- a/crates/mentat-parser/src/balance_changes_test.rs
+++ b/crates/mentat-parser/src/balance_changes_test.rs
@@ -10,7 +10,7 @@ pub fn simple_asserter_configuration(
                 network: "mainnet".to_string(),
                 ..Default::default()
             }),
-            Some(NullableBlockIdentifier {
+            Some(UncheckedBlockIdentifier {
                 hash: "block 0".to_string(),
                 index: 0,
             }),

--- a/crates/mentat-server/src/api/call.rs
+++ b/crates/mentat-server/src/api/call.rs
@@ -28,10 +28,10 @@ pub trait CallerCallApi: CallApi + Clone + Default {
         &self,
         caller: Caller,
         asserter: &Asserter,
-        data: Option<NullableCallRequest>,
+        data: Option<UncheckedCallRequest>,
         mode: &Mode,
         rpc_caller: RpcCaller,
-    ) -> MentatResponse<NullableCallResponse> {
+    ) -> MentatResponse<UncheckedCallResponse> {
         if mode.is_offline() {
             MentatError::unavailable_offline(Some(mode))
         } else {

--- a/crates/mentat-server/src/api/construction.rs
+++ b/crates/mentat-server/src/api/construction.rs
@@ -139,10 +139,10 @@ pub trait CallerConstructionApi: Clone + ConstructionApi {
         &self,
         caller: Caller,
         asserter: &Asserter,
-        data: Option<NullableConstructionCombineRequest>,
+        data: Option<UncheckedConstructionCombineRequest>,
         _mode: &Mode,
         rpc_caller: RpcCaller,
-    ) -> MentatResponse<NullableConstructionCombineResponse> {
+    ) -> MentatResponse<UncheckedConstructionCombineResponse> {
         asserter.construction_combine_request(data.as_ref())?;
         let resp = self
             .combine(caller, data.unwrap().into(), rpc_caller)
@@ -159,10 +159,10 @@ pub trait CallerConstructionApi: Clone + ConstructionApi {
         &self,
         caller: Caller,
         asserter: &Asserter,
-        data: Option<NullableConstructionDeriveRequest>,
+        data: Option<UncheckedConstructionDeriveRequest>,
         _mode: &Mode,
         rpc_caller: RpcCaller,
-    ) -> MentatResponse<NullableConstructionDeriveResponse> {
+    ) -> MentatResponse<UncheckedConstructionDeriveResponse> {
         asserter.construction_derive_request(data.as_ref())?;
         let resp = self
             .derive(caller, data.unwrap().into(), rpc_caller)
@@ -179,10 +179,10 @@ pub trait CallerConstructionApi: Clone + ConstructionApi {
         &self,
         caller: Caller,
         asserter: &Asserter,
-        data: Option<NullableConstructionHashRequest>,
+        data: Option<UncheckedConstructionHashRequest>,
         _mode: &Mode,
         rpc_caller: RpcCaller,
-    ) -> MentatResponse<NullableTransactionIdentifierResponse> {
+    ) -> MentatResponse<UncheckedTransactionIdentifierResponse> {
         asserter.construction_hash_request(data.as_ref())?;
         let resp = self
             .hash(caller, data.unwrap().into(), rpc_caller)
@@ -199,10 +199,10 @@ pub trait CallerConstructionApi: Clone + ConstructionApi {
         &self,
         caller: Caller,
         asserter: &Asserter,
-        data: Option<NullableConstructionMetadataRequest>,
+        data: Option<UncheckedConstructionMetadataRequest>,
         mode: &Mode,
         rpc_caller: RpcCaller,
-    ) -> MentatResponse<NullableConstructionMetadataResponse> {
+    ) -> MentatResponse<UncheckedConstructionMetadataResponse> {
         if mode.is_offline() {
             MentatError::unavailable_offline(Some(mode))
         } else {
@@ -223,10 +223,10 @@ pub trait CallerConstructionApi: Clone + ConstructionApi {
         &self,
         caller: Caller,
         asserter: &Asserter,
-        data: Option<NullableConstructionParseRequest>,
+        data: Option<UncheckedConstructionParseRequest>,
         _mode: &Mode,
         rpc_caller: RpcCaller,
-    ) -> MentatResponse<NullableConstructionParseResponse> {
+    ) -> MentatResponse<UncheckedConstructionParseResponse> {
         asserter.construction_parse_request(data.as_ref())?;
         let data: ConstructionParseRequest = data.unwrap().into();
         // let signed = data.signed;
@@ -244,10 +244,10 @@ pub trait CallerConstructionApi: Clone + ConstructionApi {
         &self,
         caller: Caller,
         asserter: &Asserter,
-        data: Option<NullableConstructionPayloadsRequest>,
+        data: Option<UncheckedConstructionPayloadsRequest>,
         _mode: &Mode,
         rpc_caller: RpcCaller,
-    ) -> MentatResponse<NullableConstructionPayloadsResponse> {
+    ) -> MentatResponse<UncheckedConstructionPayloadsResponse> {
         asserter.construction_payload_request(data.as_ref())?;
         let resp = self
             .payloads(caller, data.unwrap().into(), rpc_caller)
@@ -264,10 +264,10 @@ pub trait CallerConstructionApi: Clone + ConstructionApi {
         &self,
         caller: Caller,
         asserter: &Asserter,
-        data: Option<NullableConstructionPreprocessRequest>,
+        data: Option<UncheckedConstructionPreprocessRequest>,
         _mode: &Mode,
         rpc_caller: RpcCaller,
-    ) -> MentatResponse<NullableConstructionPreprocessResponse> {
+    ) -> MentatResponse<UncheckedConstructionPreprocessResponse> {
         asserter.construction_preprocess_request(data.as_ref())?;
         let resp = self
             .preprocess(caller, data.unwrap().into(), rpc_caller)
@@ -284,10 +284,10 @@ pub trait CallerConstructionApi: Clone + ConstructionApi {
         &self,
         caller: Caller,
         asserter: &Asserter,
-        data: Option<NullableConstructionSubmitRequest>,
+        data: Option<UncheckedConstructionSubmitRequest>,
         mode: &Mode,
         rpc_caller: RpcCaller,
-    ) -> MentatResponse<NullableTransactionIdentifierResponse> {
+    ) -> MentatResponse<UncheckedTransactionIdentifierResponse> {
         if mode.is_offline() {
             MentatError::unavailable_offline(Some(mode))
         } else {

--- a/crates/mentat-server/src/api/data.rs
+++ b/crates/mentat-server/src/api/data.rs
@@ -194,10 +194,10 @@ pub trait CallerDataApi: Clone + DataApi {
         &self,
         caller: Caller,
         asserter: &Asserter,
-        data: Option<NullableMetadataRequest>,
+        data: Option<UncheckedMetadataRequest>,
         _mode: &Mode,
         rpc_caller: RpcCaller,
-    ) -> MentatResponse<NullableNetworkListResponse> {
+    ) -> MentatResponse<UncheckedNetworkListResponse> {
         asserter.metadata_request(data.as_ref())?;
         let resp = self
             .network_list(caller, data.unwrap().into(), rpc_caller)
@@ -214,10 +214,10 @@ pub trait CallerDataApi: Clone + DataApi {
         &self,
         caller: Caller,
         asserter: &Asserter,
-        data: Option<NullableNetworkRequest>,
+        data: Option<UncheckedNetworkRequest>,
         _mode: &Mode,
         rpc_caller: RpcCaller,
-    ) -> MentatResponse<NullableNetworkOptionsResponse> {
+    ) -> MentatResponse<UncheckedNetworkOptionsResponse> {
         asserter.network_request(data.as_ref())?;
         let resp = self
             .network_options(caller, data.unwrap().into(), rpc_caller)
@@ -234,10 +234,10 @@ pub trait CallerDataApi: Clone + DataApi {
         &self,
         caller: Caller,
         asserter: &Asserter,
-        data: Option<NullableNetworkRequest>,
+        data: Option<UncheckedNetworkRequest>,
         mode: &Mode,
         rpc_caller: RpcCaller,
-    ) -> MentatResponse<NullableNetworkStatusResponse> {
+    ) -> MentatResponse<UncheckedNetworkStatusResponse> {
         if mode.is_offline() {
             MentatError::unavailable_offline(Some(mode))
         } else {
@@ -258,10 +258,10 @@ pub trait CallerDataApi: Clone + DataApi {
         &self,
         caller: Caller,
         asserter: &Asserter,
-        data: Option<NullableAccountBalanceRequest>,
+        data: Option<UncheckedAccountBalanceRequest>,
         mode: &Mode,
         rpc_caller: RpcCaller,
-    ) -> MentatResponse<NullableAccountBalanceResponse> {
+    ) -> MentatResponse<UncheckedAccountBalanceResponse> {
         if mode.is_offline() {
             MentatError::unavailable_offline(Some(mode))
         } else {
@@ -287,10 +287,10 @@ pub trait CallerDataApi: Clone + DataApi {
         &self,
         caller: Caller,
         asserter: &Asserter,
-        data: Option<NullableAccountCoinsRequest>,
+        data: Option<UncheckedAccountCoinsRequest>,
         mode: &Mode,
         rpc_caller: RpcCaller,
-    ) -> MentatResponse<NullableAccountCoinsResponse> {
+    ) -> MentatResponse<UncheckedAccountCoinsResponse> {
         if mode.is_offline() {
             MentatError::unavailable_offline(Some(mode))
         } else {
@@ -311,15 +311,15 @@ pub trait CallerDataApi: Clone + DataApi {
         &self,
         caller: Caller,
         asserter: &Asserter,
-        data: Option<NullableBlockRequest>,
+        data: Option<UncheckedBlockRequest>,
         mode: &Mode,
         rpc_caller: RpcCaller,
-    ) -> MentatResponse<NullableBlockResponse> {
+    ) -> MentatResponse<UncheckedBlockResponse> {
         if mode.is_offline() {
             MentatError::unavailable_offline(Some(mode))
         } else {
             asserter.block_request(data.as_ref())?;
-            let resp: NullableBlockResponse = self
+            let resp: UncheckedBlockResponse = self
                 .block(caller, data.unwrap().into(), rpc_caller)
                 .await?
                 .into();
@@ -335,15 +335,15 @@ pub trait CallerDataApi: Clone + DataApi {
         &self,
         caller: Caller,
         asserter: &Asserter,
-        data: Option<NullableBlockTransactionRequest>,
+        data: Option<UncheckedBlockTransactionRequest>,
         mode: &Mode,
         rpc_caller: RpcCaller,
-    ) -> MentatResponse<NullableBlockTransactionResponse> {
+    ) -> MentatResponse<UncheckedBlockTransactionResponse> {
         if mode.is_offline() {
             MentatError::unavailable_offline(Some(mode))
         } else {
             asserter.block_transaction_request(data.as_ref())?;
-            let resp: NullableBlockTransactionResponse = self
+            let resp: UncheckedBlockTransactionResponse = self
                 .block_transaction(caller, data.unwrap().into(), rpc_caller)
                 .await?
                 .into();
@@ -359,15 +359,15 @@ pub trait CallerDataApi: Clone + DataApi {
         &self,
         caller: Caller,
         asserter: &Asserter,
-        data: Option<NullableNetworkRequest>,
+        data: Option<UncheckedNetworkRequest>,
         mode: &Mode,
         rpc_caller: RpcCaller,
-    ) -> MentatResponse<NullableMempoolResponse> {
+    ) -> MentatResponse<UncheckedMempoolResponse> {
         if mode.is_offline() {
             MentatError::unavailable_offline(Some(mode))
         } else {
             asserter.network_request(data.as_ref())?;
-            let resp: NullableMempoolResponse = self
+            let resp: UncheckedMempoolResponse = self
                 .mempool(caller, data.unwrap().into(), rpc_caller)
                 .await?
                 .into();
@@ -383,15 +383,15 @@ pub trait CallerDataApi: Clone + DataApi {
         &self,
         caller: Caller,
         asserter: &Asserter,
-        data: Option<NullableMempoolTransactionRequest>,
+        data: Option<UncheckedMempoolTransactionRequest>,
         mode: &Mode,
         rpc_caller: RpcCaller,
-    ) -> MentatResponse<NullableMempoolTransactionResponse> {
+    ) -> MentatResponse<UncheckedMempoolTransactionResponse> {
         if mode.is_offline() {
             MentatError::unavailable_offline(Some(mode))
         } else {
             asserter.mempool_transaction_request(data.as_ref())?;
-            let resp: NullableMempoolTransactionResponse = self
+            let resp: UncheckedMempoolTransactionResponse = self
                 .mempool_transaction(caller, data.unwrap().into(), rpc_caller)
                 .await?
                 .into();

--- a/crates/mentat-server/src/api/indexer.rs
+++ b/crates/mentat-server/src/api/indexer.rs
@@ -53,10 +53,10 @@ pub trait CallerIndexerApi: Clone + IndexerApi {
         &self,
         caller: Caller,
         asserter: &Asserter,
-        data: Option<NullableEventsBlocksRequest>,
+        data: Option<UncheckedEventsBlocksRequest>,
         _mode: &Mode,
         rpc_caller: RpcCaller,
-    ) -> MentatResponse<NullableEventsBlocksResponse> {
+    ) -> MentatResponse<UncheckedEventsBlocksResponse> {
         asserter.events_block_request(data.as_ref())?;
         let resp = self
             .events_blocks(caller, data.unwrap().into(), rpc_caller)
@@ -73,10 +73,10 @@ pub trait CallerIndexerApi: Clone + IndexerApi {
         &self,
         caller: Caller,
         asserter: &Asserter,
-        data: Option<NullableSearchTransactionsRequest>,
+        data: Option<UncheckedSearchTransactionsRequest>,
         _mode: &Mode,
         rpc_caller: RpcCaller,
-    ) -> MentatResponse<NullableSearchTransactionsResponse> {
+    ) -> MentatResponse<UncheckedSearchTransactionsResponse> {
         asserter.search_transactions_request(data.as_ref())?;
         let resp = self
             .search_transactions(caller, data.unwrap().into(), rpc_caller)

--- a/crates/mentat-types/src/errors/server_error.rs
+++ b/crates/mentat-types/src/errors/server_error.rs
@@ -11,19 +11,19 @@ use axum::{
 use super::*;
 
 /// The Error type for any mentat responses.
-#[derive(Clone, Debug, Default, Deserialize, Serialize, PartialEq, Eq, Nullable)]
-pub struct NullableMentatError {
+#[derive(Clone, Debug, Default, Deserialize, Serialize, PartialEq, Eq, Unchecked)]
+pub struct UncheckedMentatError {
     /// The http status code.
     #[serde(skip)]
     pub status_code: u16,
     /// The rosetta error code
-    #[nullable(usize)]
+    #[unchecked(usize)]
     pub code: isize,
     /// The message for the error.
     pub message: String,
     /// The optional description of the error.
     #[serde(skip_serializing_if = "Option::is_none")]
-    #[nullable(retain)]
+    #[unchecked(retain)]
     pub description: Option<String>,
     /// If the method is retriable.
     pub retriable: bool,

--- a/crates/mentat-types/src/errors/server_error.rs
+++ b/crates/mentat-types/src/errors/server_error.rs
@@ -11,17 +11,19 @@ use axum::{
 use super::*;
 
 /// The Error type for any mentat responses.
-#[derive(Clone, Debug, Default, Deserialize, Serialize, PartialEq, Eq)]
-pub struct MentatError {
+#[derive(Clone, Debug, Default, Deserialize, Serialize, PartialEq, Eq, Nullable)]
+pub struct NullableMentatError {
     /// The http status code.
     #[serde(skip)]
     pub status_code: u16,
     /// The rosetta error code
-    pub code: i32,
+    #[nullable(usize)]
+    pub code: isize,
     /// The message for the error.
     pub message: String,
     /// The optional description of the error.
     #[serde(skip_serializing_if = "Option::is_none")]
+    #[nullable(retain)]
     pub description: Option<String>,
     /// If the method is retriable.
     pub retriable: bool,

--- a/crates/mentat-types/src/identifiers/block_identifier.rs
+++ b/crates/mentat-types/src/identifiers/block_identifier.rs
@@ -5,11 +5,11 @@ use from_tuple::FromTuple;
 use super::*;
 
 /// The [`BlockIdentifier`] uniquely identifies a block in a particular network.
-#[derive(Clone, Debug, Default, Deserialize, FromTuple, Serialize, PartialEq, Eq, Nullable)]
+#[derive(Clone, Debug, Default, Deserialize, FromTuple, Serialize, PartialEq, Eq, Unchecked)]
 #[serde(default)]
-pub struct NullableBlockIdentifier {
+pub struct UncheckedBlockIdentifier {
     /// This is also known as the block height.
-    #[nullable(usize)]
+    #[unchecked(usize)]
     pub index: isize,
     /// The block hash..
     pub hash: String,

--- a/crates/mentat-types/src/identifiers/block_identifier.rs
+++ b/crates/mentat-types/src/identifiers/block_identifier.rs
@@ -5,11 +5,12 @@ use from_tuple::FromTuple;
 use super::*;
 
 /// The [`BlockIdentifier`] uniquely identifies a block in a particular network.
-#[derive(Clone, Debug, Default, Deserialize, FromTuple, Serialize, PartialEq, Eq)]
+#[derive(Clone, Debug, Default, Deserialize, FromTuple, Serialize, PartialEq, Eq, Nullable)]
 #[serde(default)]
-pub struct BlockIdentifier {
+pub struct NullableBlockIdentifier {
     /// This is also known as the block height.
-    pub index: i64,
+    #[nullable(usize)]
+    pub index: isize,
     /// The block hash..
     pub hash: String,
 }

--- a/crates/mentat-types/src/identifiers/network_identifier.rs
+++ b/crates/mentat-types/src/identifiers/network_identifier.rs
@@ -58,7 +58,7 @@ impl From<(&str, &str, Option<&str>)> for NetworkIdentifier {
     }
 }
 
-impl From<Option<NetworkIdentifier>> for NullableNetworkRequest {
+impl From<Option<NetworkIdentifier>> for UncheckedNetworkRequest {
     fn from(net: Option<NetworkIdentifier>) -> Self {
         Self {
             network_identifier: net,

--- a/crates/mentat-types/src/identifiers/operation_identifier.rs
+++ b/crates/mentat-types/src/identifiers/operation_identifier.rs
@@ -4,15 +4,15 @@ use super::*;
 
 /// The [`OperationIdentifier`] uniquely identifies an operation within a
 /// transaction.
-#[derive(Clone, Debug, Default, Deserialize, Serialize, PartialEq, Eq, Nullable)]
+#[derive(Clone, Debug, Default, Deserialize, Serialize, PartialEq, Eq, Unchecked)]
 #[serde(default)]
-pub struct NullableOperationIdentifier {
+pub struct UncheckedOperationIdentifier {
     /// The operation index is used to ensure each operation has a unique
     /// identifier within a transaction. This index is only relative to the
     /// transaction and NOT GLOBAL. The operations in each transaction should
     /// start from index 0. To clarify, there may not be any notion of an
     /// operation index in the blockchain being described.
-    #[nullable(usize)]
+    #[unchecked(usize)]
     pub index: isize,
     /// Some blockchains specify an operation index that is essential for client
     /// use. For example, Bitcoin uses a `network_index` to identify which UTXO
@@ -20,7 +20,7 @@ pub struct NullableOperationIdentifier {
     /// there is no notion of an operation index in a blockchain (typically most
     /// account-based blockchains).
     #[serde(skip_serializing_if = "Option::is_none")]
-    #[nullable(option_usize)]
+    #[unchecked(option_usize)]
     pub network_index: Option<isize>,
 }
 

--- a/crates/mentat-types/src/identifiers/operation_identifier.rs
+++ b/crates/mentat-types/src/identifiers/operation_identifier.rs
@@ -4,26 +4,28 @@ use super::*;
 
 /// The [`OperationIdentifier`] uniquely identifies an operation within a
 /// transaction.
-#[derive(Clone, Debug, Default, Deserialize, Serialize, PartialEq, Eq)]
+#[derive(Clone, Debug, Default, Deserialize, Serialize, PartialEq, Eq, Nullable)]
 #[serde(default)]
-pub struct OperationIdentifier {
+pub struct NullableOperationIdentifier {
     /// The operation index is used to ensure each operation has a unique
     /// identifier within a transaction. This index is only relative to the
     /// transaction and NOT GLOBAL. The operations in each transaction should
     /// start from index 0. To clarify, there may not be any notion of an
     /// operation index in the blockchain being described.
-    pub index: i64,
+    #[nullable(usize)]
+    pub index: isize,
     /// Some blockchains specify an operation index that is essential for client
     /// use. For example, Bitcoin uses a `network_index` to identify which UTXO
     /// was used in a transaction. `network_index` should not be populated if
     /// there is no notion of an operation index in a blockchain (typically most
     /// account-based blockchains).
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub network_index: Option<i64>,
+    #[nullable(option_usize)]
+    pub network_index: Option<isize>,
 }
 
-impl From<i64> for OperationIdentifier {
-    fn from(index: i64) -> Self {
+impl From<usize> for OperationIdentifier {
+    fn from(index: usize) -> Self {
         Self {
             index,
             ..Default::default()
@@ -31,8 +33,8 @@ impl From<i64> for OperationIdentifier {
     }
 }
 
-impl From<(i64, i64)> for OperationIdentifier {
-    fn from((index, net_index): (i64, i64)) -> Self {
+impl From<(usize, usize)> for OperationIdentifier {
+    fn from((index, net_index): (usize, usize)) -> Self {
         Self {
             index,
             network_index: Some(net_index),
@@ -40,8 +42,8 @@ impl From<(i64, i64)> for OperationIdentifier {
     }
 }
 
-impl From<(i64, Option<i64>)> for OperationIdentifier {
-    fn from((index, net_index): (i64, Option<i64>)) -> Self {
+impl From<(usize, Option<usize>)> for OperationIdentifier {
+    fn from((index, net_index): (usize, Option<usize>)) -> Self {
         Self {
             index,
             network_index: net_index,

--- a/crates/mentat-types/src/identifiers/partial_block_identifier.rs
+++ b/crates/mentat-types/src/identifiers/partial_block_identifier.rs
@@ -7,16 +7,16 @@ use super::*;
 /// When fetching data by [`BlockIdentifier`], it may be possible to only
 /// specify the index or hash. If neither property is specified, it is assumed
 /// that the client is making a request at the current block.
-#[derive(Clone, Debug, Default, Deserialize, FromTuple, Serialize, PartialEq, Eq, Nullable)]
+#[derive(Clone, Debug, Default, Deserialize, FromTuple, Serialize, PartialEq, Eq, Unchecked)]
 #[serde(default)]
-pub struct NullablePartialBlockIdentifier {
+pub struct UncheckedPartialBlockIdentifier {
     /// This is also known as the block height.
     #[serde(skip_serializing_if = "Option::is_none")]
-    #[nullable(option_usize)]
+    #[unchecked(option_usize)]
     pub index: Option<isize>,
     /// The block hash.
     #[serde(skip_serializing_if = "Option::is_none")]
-    #[nullable(retain)]
+    #[unchecked(retain)]
     pub hash: Option<String>,
 }
 

--- a/crates/mentat-types/src/identifiers/partial_block_identifier.rs
+++ b/crates/mentat-types/src/identifiers/partial_block_identifier.rs
@@ -7,19 +7,21 @@ use super::*;
 /// When fetching data by [`BlockIdentifier`], it may be possible to only
 /// specify the index or hash. If neither property is specified, it is assumed
 /// that the client is making a request at the current block.
-#[derive(Clone, Debug, Default, Deserialize, FromTuple, Serialize, PartialEq, Eq)]
+#[derive(Clone, Debug, Default, Deserialize, FromTuple, Serialize, PartialEq, Eq, Nullable)]
 #[serde(default)]
-pub struct PartialBlockIdentifier {
+pub struct NullablePartialBlockIdentifier {
     /// This is also known as the block height.
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub index: Option<i64>,
+    #[nullable(option_usize)]
+    pub index: Option<isize>,
     /// The block hash.
     #[serde(skip_serializing_if = "Option::is_none")]
+    #[nullable(retain)]
     pub hash: Option<String>,
 }
 
-impl From<i64> for PartialBlockIdentifier {
-    fn from(index: i64) -> Self {
+impl From<usize> for PartialBlockIdentifier {
+    fn from(index: usize) -> Self {
         Self {
             index: Some(index),
             ..Default::default()

--- a/crates/mentat-types/src/lib.rs
+++ b/crates/mentat-types/src/lib.rs
@@ -4,7 +4,7 @@
 #![allow(unused)]
 
 use indexmap::IndexMap;
-use mentat_macros::Nullable;
+use mentat_macros::Unchecked;
 use serde::{Deserialize, Serialize};
 use serde_json::Value;
 

--- a/crates/mentat-types/src/misc/sync_status.rs
+++ b/crates/mentat-types/src/misc/sync_status.rs
@@ -1,6 +1,6 @@
 //! The module defines the `SyncStatus`.
 
-use mentat_macros::Nullable;
+use mentat_macros::Unchecked;
 
 use super::*;
 
@@ -9,9 +9,9 @@ use super::*;
 /// to indicate healthiness when block data cannot be queried until some sync
 /// phase completes or cannot be determined by comparing the timestamp of the
 /// most recent block with the current time.
-#[derive(Clone, Debug, Default, Deserialize, Serialize, PartialEq, Eq, Nullable)]
+#[derive(Clone, Debug, Default, Deserialize, Serialize, PartialEq, Eq, Unchecked)]
 #[serde(default)]
-pub struct NullableSyncStatus {
+pub struct UncheckedSyncStatus {
     /// `CurrentIndex` is the index of the last synced block in the current
     /// stage. This is a separate field from `current_block_identifier` in
     /// [`crate::responses::NetworkStatusResponse`] because blocks with indices
@@ -22,12 +22,12 @@ pub struct NullableSyncStatus {
     /// the `/block` endpoint (excluding indices less than
     /// `oldest_block_identifier`).
     #[serde(skip_serializing_if = "Option::is_none")]
-    #[nullable(option_usize)]
+    #[unchecked(option_usize)]
     pub current_index: Option<isize>,
     /// `TargetIndex` is the index of the block that the implementation is
     /// attempting to sync to in the current stage.
     #[serde(skip_serializing_if = "Option::is_none")]
-    #[nullable(option_usize)]
+    #[unchecked(option_usize)]
     pub target_index: Option<isize>,
     /// Stage is the phase of the sync process.
     #[serde(skip_serializing_if = "Option::is_none")]

--- a/crates/mentat-types/src/misc/sync_status.rs
+++ b/crates/mentat-types/src/misc/sync_status.rs
@@ -1,5 +1,7 @@
 //! The module defines the `SyncStatus`.
 
+use mentat_macros::Nullable;
+
 use super::*;
 
 /// [`SyncStatus`] is used to provide additional context about an
@@ -7,9 +9,9 @@ use super::*;
 /// to indicate healthiness when block data cannot be queried until some sync
 /// phase completes or cannot be determined by comparing the timestamp of the
 /// most recent block with the current time.
-#[derive(Clone, Debug, Default, Deserialize, Serialize, PartialEq, Eq)]
+#[derive(Clone, Debug, Default, Deserialize, Serialize, PartialEq, Eq, Nullable)]
 #[serde(default)]
-pub struct SyncStatus {
+pub struct NullableSyncStatus {
     /// `CurrentIndex` is the index of the last synced block in the current
     /// stage. This is a separate field from `current_block_identifier` in
     /// [`crate::responses::NetworkStatusResponse`] because blocks with indices
@@ -20,11 +22,13 @@ pub struct SyncStatus {
     /// the `/block` endpoint (excluding indices less than
     /// `oldest_block_identifier`).
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub current_index: Option<i64>,
+    #[nullable(option_usize)]
+    pub current_index: Option<isize>,
     /// `TargetIndex` is the index of the block that the implementation is
     /// attempting to sync to in the current stage.
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub target_index: Option<i64>,
+    #[nullable(option_usize)]
+    pub target_index: Option<isize>,
     /// Stage is the phase of the sync process.
     #[serde(skip_serializing_if = "Option::is_none")]
     pub stage: Option<String>,

--- a/crates/mentat-types/src/models/account_coin.rs
+++ b/crates/mentat-types/src/models/account_coin.rs
@@ -3,13 +3,13 @@
 use super::*;
 
 /// `AccountCoin` contains an [`AccountIdentifier`] and a [`Coin`] that it owns.
-#[derive(Clone, Debug, Default, Deserialize, Serialize, Nullable)]
+#[derive(Clone, Debug, Default, Deserialize, Serialize, Unchecked)]
 #[serde(default)]
-pub struct NullableAccountCoin {
+pub struct UncheckedAccountCoin {
     /// the `AccountIdentifier` that owns the [`Coin`]
     #[serde(skip_serializing_if = "Option::is_none")]
     account: Option<AccountIdentifier>,
     /// the `Coin` that the [`AccountIdentifier`] owns
     #[serde(skip_serializing_if = "Option::is_none")]
-    coin: Option<NullableCoin>,
+    coin: Option<UncheckedCoin>,
 }

--- a/crates/mentat-types/src/models/account_currency.rs
+++ b/crates/mentat-types/src/models/account_currency.rs
@@ -5,13 +5,13 @@ use super::*;
 /// `AccountCurrency` is a simple struct combining
 /// an [`AccountIdentifier`] and [`Currency`]. This can
 /// be useful for looking up balances.
-#[derive(Clone, Debug, Default, Deserialize, Serialize, Nullable)]
+#[derive(Clone, Debug, Default, Deserialize, Serialize, Unchecked)]
 #[serde(default)]
-pub struct NullableAccountCurrency {
+pub struct UncheckedAccountCurrency {
     /// the identifier for the [`Account`]
     #[serde(skip_serializing_if = "Option::is_none")]
     account: Option<AccountIdentifier>,
     /// the currency used by the [`Account`]
     #[serde(skip_serializing_if = "Option::is_none")]
-    currency: Option<NullableCurrency>,
+    currency: Option<UncheckedCurrency>,
 }

--- a/crates/mentat-types/src/models/allow.rs
+++ b/crates/mentat-types/src/models/allow.rs
@@ -7,9 +7,9 @@ use super::*;
 /// validate the correctness of a Rosetta Server implementation. It is expected
 /// that these clients will error if they receive some response that contains
 /// any of the above information that is not specified here.
-#[derive(Clone, Debug, Default, Deserialize, Serialize, Nullable)]
+#[derive(Clone, Debug, Default, Deserialize, Serialize, Unchecked)]
 #[serde(default)]
-pub struct NullableAllow {
+pub struct UncheckedAllow {
     /// All `OperationStatus` this implementation supports. Any status that is
     /// returned during parsing that is not listed here will cause client
     /// validation to error.
@@ -33,7 +33,7 @@ pub struct NullableAllow {
         skip_serializing_if = "Vec::is_empty",
         deserialize_with = "null_default"
     )]
-    pub errors: Vec<Option<NullableMentatError>>,
+    pub errors: Vec<Option<UncheckedMentatError>>,
     /// Any Rosetta implementation that supports querying the balance of an
     /// account at any height in the past should set this to true.
     pub historical_balance_lookup: bool,
@@ -44,7 +44,7 @@ pub struct NullableAllow {
     /// populated, block timestamps are assumed to be valid for all available
     /// blocks.
     #[serde(skip_serializing_if = "Option::is_none")]
-    #[nullable(option_usize)]
+    #[unchecked(option_usize)]
     pub timestamp_start_index: Option<isize>,
     /// All methods that are supported by the `/call` endpoint. Communicating
     /// which parameters should be provided to `/call` is the responsibility of
@@ -66,7 +66,7 @@ pub struct NullableAllow {
         skip_serializing_if = "Vec::is_empty",
         deserialize_with = "null_default"
     )]
-    pub balance_exemptions: Vec<Option<NullableBalanceExemption>>,
+    pub balance_exemptions: Vec<Option<UncheckedBalanceExemption>>,
     /// Any Rosetta implementation that can update an [`AccountIdentifier`]'s
     /// unspent coins based on the contents of the mempool should populate this
     /// field as true. If false, requests to `/account/coins` that set

--- a/crates/mentat-types/src/models/allow.rs
+++ b/crates/mentat-types/src/models/allow.rs
@@ -33,7 +33,7 @@ pub struct NullableAllow {
         skip_serializing_if = "Vec::is_empty",
         deserialize_with = "null_default"
     )]
-    pub errors: Vec<Option<MentatError>>,
+    pub errors: Vec<Option<NullableMentatError>>,
     /// Any Rosetta implementation that supports querying the balance of an
     /// account at any height in the past should set this to true.
     pub historical_balance_lookup: bool,
@@ -44,8 +44,8 @@ pub struct NullableAllow {
     /// populated, block timestamps are assumed to be valid for all available
     /// blocks.
     #[serde(skip_serializing_if = "Option::is_none")]
-    #[nullable(retain)]
-    pub timestamp_start_index: Option<i64>,
+    #[nullable(option_usize)]
+    pub timestamp_start_index: Option<isize>,
     /// All methods that are supported by the `/call` endpoint. Communicating
     /// which parameters should be provided to `/call` is the responsibility of
     /// the implementer (this is en lieu of defining an entire type system and

--- a/crates/mentat-types/src/models/amount.rs
+++ b/crates/mentat-types/src/models/amount.rs
@@ -6,9 +6,9 @@ use super::*;
 
 /// Amount is some Value of a [`Currency`]. It is considered invalid to specify
 /// a Value without a [`Currency`].
-#[derive(Clone, Debug, Default, Deserialize, Serialize, PartialEq, Eq, Nullable)]
+#[derive(Clone, Debug, Default, Deserialize, Serialize, PartialEq, Eq, Unchecked)]
 #[serde(default)]
-pub struct NullableAmount {
+pub struct UncheckedAmount {
     /// Value of the transaction in atomic units represented as an
     /// arbitrary-sized signed integer. For example, 1 BTC would be represented
     /// by a value of 100000000.
@@ -17,7 +17,7 @@ pub struct NullableAmount {
     /// Decimals value is used to convert an Amount.Value from atomic units
     /// (Satoshis) to standard units (Bitcoins).
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub currency: Option<NullableCurrency>,
+    pub currency: Option<UncheckedCurrency>,
     #[allow(clippy::missing_docs_in_private_items)]
     #[serde(skip_serializing_if = "IndexMap::is_empty")]
     pub metadata: IndexMap<String, Value>,

--- a/crates/mentat-types/src/models/balance_exemption.rs
+++ b/crates/mentat-types/src/models/balance_exemption.rs
@@ -14,21 +14,21 @@ use super::*;
 /// balance changes. If your implementation relies on any `[BalanceExemption]`s,
 /// you MUST implement historical balance lookup (the ability to query an
 /// account balance at any [`BlockIdentifier`]).
-#[derive(Clone, Debug, Default, Deserialize, Serialize, Nullable)]
+#[derive(Clone, Debug, Default, Deserialize, Serialize, Unchecked)]
 #[serde(default)]
-pub struct NullableBalanceExemption {
+pub struct UncheckedBalanceExemption {
     /// SubAccountAddress is the [`SubAccountIdentifier`]. Address that the
     /// BalanceExemption applies to (regardless of the value of
     /// [`SubAccountIdentifier`].Metadata).
     #[serde(skip_serializing_if = "Option::is_none")]
-    #[nullable(retain)]
+    #[unchecked(retain)]
     pub sub_account_address: Option<String>,
     /// `Currency` is composed of a canonical Symbol and Decimals. This Decimals
     /// value is used to convert an Amount.Value from atomic units (Satoshis) to
     /// standard units (Bitcoins).
     #[serde(skip_serializing_if = "Option::is_none")]
-    #[nullable(retain)]
-    pub currency: Option<NullableCurrency>,
+    #[unchecked(retain)]
+    pub currency: Option<UncheckedCurrency>,
     /// `ExemptionType` is used to indicate if the live balance for an account
     /// subject to a [`BalanceExemption`] could increase above, decrease below,
     /// or equal the computed balance. * `greater_or_equal`: The live
@@ -39,6 +39,6 @@ pub struct NullableBalanceExemption {
     /// to spendable on a vesting account. * dynamic: The live balance may
     /// increase above, decrease below, or equal the computed balance. This
     /// typically occurs with tokens that have a dynamic supply.
-    #[nullable(option_enum)]
-    pub exemption_type: NullableExemptionType,
+    #[unchecked(option_enum)]
+    pub exemption_type: UncheckedExemptionType,
 }

--- a/crates/mentat-types/src/models/block.rs
+++ b/crates/mentat-types/src/models/block.rs
@@ -16,15 +16,16 @@ pub struct NullableBlock {
     /// The [`BlockIdentifier`] uniquely identifies a block in a particular
     /// network.
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub block_identifier: Option<BlockIdentifier>,
+    pub block_identifier: Option<NullableBlockIdentifier>,
     /// The [`BlockIdentifier`] uniquely identifies a block in a particular
     /// network.
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub parent_block_identifier: Option<BlockIdentifier>,
+    pub parent_block_identifier: Option<NullableBlockIdentifier>,
     /// The timestamp of the block in milliseconds since the Unix Epoch. The
     /// timestamp is stored in milliseconds because some blockchains produce
     /// blocks more often than once a second.
-    pub timestamp: i64,
+    #[nullable(usize)]
+    pub timestamp: isize,
     /// The list of [`Transaction`]s related to the block.
     #[serde(
         skip_serializing_if = "Vec::is_empty",

--- a/crates/mentat-types/src/models/block.rs
+++ b/crates/mentat-types/src/models/block.rs
@@ -10,28 +10,28 @@ use super::*;
 /// requested and received a block identified by a specific [`BlockIdentifier`],
 /// all future calls for that same [`BlockIdentifier`] must return the same
 /// block contents.
-#[derive(Clone, Debug, Default, Deserialize, Serialize, Nullable)]
+#[derive(Clone, Debug, Default, Deserialize, Serialize, Unchecked)]
 #[serde(default)]
-pub struct NullableBlock {
+pub struct UncheckedBlock {
     /// The [`BlockIdentifier`] uniquely identifies a block in a particular
     /// network.
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub block_identifier: Option<NullableBlockIdentifier>,
+    pub block_identifier: Option<UncheckedBlockIdentifier>,
     /// The [`BlockIdentifier`] uniquely identifies a block in a particular
     /// network.
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub parent_block_identifier: Option<NullableBlockIdentifier>,
+    pub parent_block_identifier: Option<UncheckedBlockIdentifier>,
     /// The timestamp of the block in milliseconds since the Unix Epoch. The
     /// timestamp is stored in milliseconds because some blockchains produce
     /// blocks more often than once a second.
-    #[nullable(usize)]
+    #[unchecked(usize)]
     pub timestamp: isize,
     /// The list of [`Transaction`]s related to the block.
     #[serde(
         skip_serializing_if = "Vec::is_empty",
         deserialize_with = "null_default"
     )]
-    pub transactions: Vec<Option<NullableTransaction>>,
+    pub transactions: Vec<Option<UncheckedTransaction>>,
     #[allow(clippy::missing_docs_in_private_items)]
     pub metadata: IndexMap<String, Value>,
 }

--- a/crates/mentat-types/src/models/block_event.rs
+++ b/crates/mentat-types/src/models/block_event.rs
@@ -9,11 +9,12 @@ use super::*;
 pub struct NullableBlockEvent {
     /// Sequence is the unique identifier of a BlockEvent within the context of
     /// a [`NetworkIdentifier`].
-    pub sequence: i64,
+    #[nullable(usize)]
+    pub sequence: isize,
     /// The `BlockIdentifier` uniquely identifies a block in a particular
     /// network.
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub block_identifier: Option<BlockIdentifier>,
+    pub block_identifier: Option<NullableBlockIdentifier>,
     /// `BlockEventType` determines if a `BlockEvent` represents the addition or
     /// removal of a block.
     #[serde(rename = "type")]

--- a/crates/mentat-types/src/models/block_event.rs
+++ b/crates/mentat-types/src/models/block_event.rs
@@ -4,20 +4,20 @@ use super::*;
 /// `BlockEvent` represents the addition or removal of a [`BlockIdentifier`]
 /// from storage. Streaming `BlockEvent`s allows lightweight clients to update
 /// their own state without needing to implement their own syncing logic.
-#[derive(Clone, Debug, Default, Deserialize, Serialize, Nullable)]
+#[derive(Clone, Debug, Default, Deserialize, Serialize, Unchecked)]
 #[serde(default)]
-pub struct NullableBlockEvent {
+pub struct UncheckedBlockEvent {
     /// Sequence is the unique identifier of a BlockEvent within the context of
     /// a [`NetworkIdentifier`].
-    #[nullable(usize)]
+    #[unchecked(usize)]
     pub sequence: isize,
     /// The `BlockIdentifier` uniquely identifies a block in a particular
     /// network.
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub block_identifier: Option<NullableBlockIdentifier>,
+    pub block_identifier: Option<UncheckedBlockIdentifier>,
     /// `BlockEventType` determines if a `BlockEvent` represents the addition or
     /// removal of a block.
     #[serde(rename = "type")]
-    #[nullable(option_enum)]
-    pub type_: NullableBlockEventType,
+    #[unchecked(option_enum)]
+    pub type_: UncheckedBlockEventType,
 }

--- a/crates/mentat-types/src/models/block_event_type.rs
+++ b/crates/mentat-types/src/models/block_event_type.rs
@@ -8,9 +8,9 @@ use super::*;
 /// removal of a block.
 #[derive(Clone, Debug, Default, Deserialize, Serialize)]
 #[serde(transparent)]
-pub struct NullableBlockEventType(String);
+pub struct UncheckedBlockEventType(String);
 
-impl NullableBlockEventType {
+impl UncheckedBlockEventType {
     /// A block was added to the canonical chain.
     pub const BLOCK_ADDED: &'static str = "block_added";
     /// A block was removed from the canonical chain in a reorg.
@@ -27,19 +27,19 @@ impl NullableBlockEventType {
     }
 }
 
-impl fmt::Display for NullableBlockEventType {
+impl fmt::Display for UncheckedBlockEventType {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         write!(f, "{}", self.0)
     }
 }
 
-impl From<String> for NullableBlockEventType {
+impl From<String> for UncheckedBlockEventType {
     fn from(bt: String) -> Self {
         Self(bt)
     }
 }
 
-impl From<&str> for NullableBlockEventType {
+impl From<&str> for UncheckedBlockEventType {
     fn from(bt: &str) -> Self {
         bt.to_string().into()
     }
@@ -57,17 +57,17 @@ pub enum BlockEventType {
     BlockRemoved,
 }
 
-impl From<NullableBlockEventType> for BlockEventType {
-    fn from(other: NullableBlockEventType) -> Self {
+impl From<UncheckedBlockEventType> for BlockEventType {
+    fn from(other: UncheckedBlockEventType) -> Self {
         match other.0.as_ref() {
-            NullableBlockEventType::BLOCK_ADDED => Self::BlockAdded,
-            NullableBlockEventType::BLOCK_REMOVED => Self::BlockRemoved,
+            UncheckedBlockEventType::BLOCK_ADDED => Self::BlockAdded,
+            UncheckedBlockEventType::BLOCK_REMOVED => Self::BlockRemoved,
             i => panic!("unsupported BlockEventType: {i}"),
         }
     }
 }
 
-impl From<BlockEventType> for NullableBlockEventType {
+impl From<BlockEventType> for UncheckedBlockEventType {
     fn from(other: BlockEventType) -> Self {
         match other {
             BlockEventType::BlockAdded => Self::BLOCK_ADDED.into(),

--- a/crates/mentat-types/src/models/block_transaction.rs
+++ b/crates/mentat-types/src/models/block_transaction.rs
@@ -4,15 +4,15 @@ use super::*;
 
 /// [`BlockTransaction`] contains a populated [`Transaction`] and the
 /// [`BlockIdentifier`] that contains it.
-#[derive(Clone, Debug, Default, Deserialize, Serialize, Nullable)]
+#[derive(Clone, Debug, Default, Deserialize, Serialize, Unchecked)]
 #[serde(default)]
-pub struct NullableBlockTransaction {
+pub struct UncheckedBlockTransaction {
     /// The [`BlockIdentifier`] uniquely identifies a block in a particular
     /// network.
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub block_identifier: Option<NullableBlockIdentifier>,
+    pub block_identifier: Option<UncheckedBlockIdentifier>,
     /// [`Transaction`]s contain an array of [`Operation`]s that are
     /// attributable to the same [`TransactionIdentifier`].
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub transaction: Option<NullableTransaction>,
+    pub transaction: Option<UncheckedTransaction>,
 }

--- a/crates/mentat-types/src/models/block_transaction.rs
+++ b/crates/mentat-types/src/models/block_transaction.rs
@@ -10,7 +10,7 @@ pub struct NullableBlockTransaction {
     /// The [`BlockIdentifier`] uniquely identifies a block in a particular
     /// network.
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub block_identifier: Option<BlockIdentifier>,
+    pub block_identifier: Option<NullableBlockIdentifier>,
     /// [`Transaction`]s contain an array of [`Operation`]s that are
     /// attributable to the same [`TransactionIdentifier`].
     #[serde(skip_serializing_if = "Option::is_none")]

--- a/crates/mentat-types/src/models/coin.rs
+++ b/crates/mentat-types/src/models/coin.rs
@@ -3,13 +3,13 @@
 use super::*;
 
 /// [`Coin`] contains its unique identifier and the amount it represents.
-#[derive(Clone, Debug, Default, Deserialize, Serialize, Nullable)]
+#[derive(Clone, Debug, Default, Deserialize, Serialize, Unchecked)]
 #[serde(default)]
-pub struct NullableCoin {
+pub struct UncheckedCoin {
     /// [`Amount`] is some Value of a [`Currency`]. It is considered invalid to
     /// specify a Value without a [`Currency`].
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub amount: Option<NullableAmount>,
+    pub amount: Option<UncheckedAmount>,
     /// [`CoinIdentifier`] uniquely identifies a Coin.
     #[serde(skip_serializing_if = "Option::is_none")]
     pub coin_identifier: Option<CoinIdentifier>,

--- a/crates/mentat-types/src/models/coin_action.rs
+++ b/crates/mentat-types/src/models/coin_action.rs
@@ -8,9 +8,9 @@ use super::*;
 /// assumed that a single Coin cannot be created or spent more than once.
 #[derive(Clone, Debug, Default, Deserialize, Serialize, PartialEq, Eq)]
 #[serde(transparent)]
-pub struct NullableCoinAction(String);
+pub struct UncheckedCoinAction(String);
 
-impl NullableCoinAction {
+impl UncheckedCoinAction {
     /// `CoinAction` indicating a Coin was created.
     pub const COIN_CREATED: &'static str = "coin_created";
     /// `CoinAction` indicating a Coin was spent.
@@ -27,19 +27,19 @@ impl NullableCoinAction {
     }
 }
 
-impl fmt::Display for NullableCoinAction {
+impl fmt::Display for UncheckedCoinAction {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         write!(f, "{}", self.0)
     }
 }
 
-impl From<String> for NullableCoinAction {
+impl From<String> for UncheckedCoinAction {
     fn from(act: String) -> Self {
         Self(act)
     }
 }
 
-impl From<&str> for NullableCoinAction {
+impl From<&str> for UncheckedCoinAction {
     fn from(act: &str) -> Self {
         act.to_string().into()
     }
@@ -68,17 +68,17 @@ impl Default for CoinAction {
     }
 }
 
-impl From<NullableCoinAction> for CoinAction {
-    fn from(other: NullableCoinAction) -> Self {
+impl From<UncheckedCoinAction> for CoinAction {
+    fn from(other: UncheckedCoinAction) -> Self {
         match other.0.as_ref() {
-            NullableCoinAction::COIN_CREATED => Self::CoinCreated,
-            NullableCoinAction::COIN_SPENT => Self::CoinSpent,
+            UncheckedCoinAction::COIN_CREATED => Self::CoinCreated,
+            UncheckedCoinAction::COIN_SPENT => Self::CoinSpent,
             i => panic!("unsupported CoinAction: {i}"),
         }
     }
 }
 
-impl From<CoinAction> for NullableCoinAction {
+impl From<CoinAction> for UncheckedCoinAction {
     fn from(other: CoinAction) -> Self {
         match other {
             CoinAction::CoinCreated => Self::COIN_CREATED.into(),

--- a/crates/mentat-types/src/models/coin_change.rs
+++ b/crates/mentat-types/src/models/coin_change.rs
@@ -8,9 +8,9 @@ use super::*;
 /// abstraction of UTXOs allows for supporting both account-based transfers and
 /// UTXO-based transfers on the same blockchain (when a transfer is
 /// account-based, don't populate this model).
-#[derive(Clone, Debug, Deserialize, Serialize, Default, PartialEq, Eq, Nullable)]
+#[derive(Clone, Debug, Deserialize, Serialize, Default, PartialEq, Eq, Unchecked)]
 #[serde(default)]
-pub struct NullableCoinChange {
+pub struct UncheckedCoinChange {
     /// [`CoinIdentifier`] uniquely identifies a Coin.
     #[serde(skip_serializing_if = "Option::is_none")]
     pub coin_identifier: Option<CoinIdentifier>,
@@ -18,5 +18,5 @@ pub struct NullableCoinChange {
     /// When a [`Coin`] is created, it is coin_created. When a [`Coin`] is
     /// spent, it is coin_spent. It is assumed that a single [`Coin'] cannot
     /// be created or spent more than once.
-    pub coin_action: NullableCoinAction,
+    pub coin_action: UncheckedCoinAction,
 }

--- a/crates/mentat-types/src/models/currency.rs
+++ b/crates/mentat-types/src/models/currency.rs
@@ -16,7 +16,8 @@ pub struct NullableCurrency {
     /// amount. For example, BTC has 8 decimals. Note that it is not possible to
     /// represent the value of some currency in atomic units that is not base
     /// 10.
-    pub decimals: i32,
+    #[nullable(usize)]
+    pub decimals: isize,
     /// Any additional information related to the currency itself. For example,
     /// it would be useful to populate this object with the contract address of
     /// an ERC-20 token.

--- a/crates/mentat-types/src/models/currency.rs
+++ b/crates/mentat-types/src/models/currency.rs
@@ -7,16 +7,16 @@ use super::*;
 /// [`Currency`] is composed of a canonical Symbol and Decimals. This Decimals
 /// value is used to convert an Amount.Value from atomic units (Satoshis) to
 /// standard units (Bitcoins).
-#[derive(Clone, Debug, Default, Eq, Deserialize, PartialEq, Serialize, Nullable)]
+#[derive(Clone, Debug, Default, Eq, Deserialize, PartialEq, Serialize, Unchecked)]
 #[serde(default)]
-pub struct NullableCurrency {
+pub struct UncheckedCurrency {
     /// Canonical symbol associated with a currency.
     pub symbol: String,
     /// Number of decimal places in the standard unit representation of the
     /// amount. For example, BTC has 8 decimals. Note that it is not possible to
     /// represent the value of some currency in atomic units that is not base
     /// 10.
-    #[nullable(usize)]
+    #[unchecked(usize)]
     pub decimals: isize,
     /// Any additional information related to the currency itself. For example,
     /// it would be useful to populate this object with the contract address of
@@ -25,7 +25,7 @@ pub struct NullableCurrency {
     pub metadata: IndexMap<String, Value>,
 }
 
-impl From<String> for NullableCurrency {
+impl From<String> for UncheckedCurrency {
     fn from(symbol: String) -> Self {
         Self {
             symbol,
@@ -34,7 +34,7 @@ impl From<String> for NullableCurrency {
     }
 }
 
-impl Sortable for NullableCurrency {
+impl Sortable for UncheckedCurrency {
     fn sort(&self) -> Self {
         let mut new = self.clone();
         new.metadata.sort_keys();

--- a/crates/mentat-types/src/models/curve_type.rs
+++ b/crates/mentat-types/src/models/curve_type.rs
@@ -7,9 +7,9 @@ use super::*;
 /// CurveType is the type of cryptographic curve associated with a PublicKey.
 #[derive(Clone, Debug, Default, Deserialize, Serialize)]
 #[serde(transparent)]
-pub struct NullableCurveType(String);
+pub struct UncheckedCurveType(String);
 
-impl NullableCurveType {
+impl UncheckedCurveType {
     /// <https://ed25519.cr.yp.to/ed25519-20110926.pdf>
     pub const EDWARDS25519: &'static str = "edwards25519";
     /// https://github.com/zcash/pasta
@@ -35,19 +35,19 @@ impl NullableCurveType {
     }
 }
 
-impl fmt::Display for NullableCurveType {
+impl fmt::Display for UncheckedCurveType {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         write!(f, "{}", self.0)
     }
 }
 
-impl From<String> for NullableCurveType {
+impl From<String> for UncheckedCurveType {
     fn from(ct: String) -> Self {
         Self(ct)
     }
 }
 
-impl From<&str> for NullableCurveType {
+impl From<&str> for UncheckedCurveType {
     fn from(ct: &str) -> Self {
         ct.to_string().into()
     }
@@ -70,20 +70,20 @@ pub enum CurveType {
     Pallas,
 }
 
-impl From<NullableCurveType> for CurveType {
-    fn from(other: NullableCurveType) -> Self {
+impl From<UncheckedCurveType> for CurveType {
+    fn from(other: UncheckedCurveType) -> Self {
         match other.0.as_ref() {
-            NullableCurveType::EDWARDS25519 => Self::Edwards25519,
-            NullableCurveType::SECP256K1 => Self::Secp256k1,
-            NullableCurveType::SECP256R1 => Self::Secp256r1,
-            NullableCurveType::TWEEDLE => Self::Tweedle,
-            NullableCurveType::PALLAS => Self::Pallas,
+            UncheckedCurveType::EDWARDS25519 => Self::Edwards25519,
+            UncheckedCurveType::SECP256K1 => Self::Secp256k1,
+            UncheckedCurveType::SECP256R1 => Self::Secp256r1,
+            UncheckedCurveType::TWEEDLE => Self::Tweedle,
+            UncheckedCurveType::PALLAS => Self::Pallas,
             i => panic!("unsupported CurveType: {i}"),
         }
     }
 }
 
-impl From<CurveType> for NullableCurveType {
+impl From<CurveType> for UncheckedCurveType {
     fn from(other: CurveType) -> Self {
         match other {
             CurveType::Edwards25519 => Self::EDWARDS25519.into(),

--- a/crates/mentat-types/src/models/direction.rs
+++ b/crates/mentat-types/src/models/direction.rs
@@ -10,9 +10,9 @@ use super::*;
 /// indicate if a transaction relation is from child to parent or the reverse.
 #[derive(Clone, Debug, Default, Deserialize, Serialize)]
 #[serde(transparent)]
-pub struct NullableDirection(String);
+pub struct UncheckedDirection(String);
 
-impl NullableDirection {
+impl UncheckedDirection {
     /// Direction indicating a transaction relation is from child to parent.
     pub const BACKWARD: &'static str = "backward";
     /// Direction indicating a transaction relation is from parent to child.
@@ -29,19 +29,19 @@ impl NullableDirection {
     }
 }
 
-impl fmt::Display for NullableDirection {
+impl fmt::Display for UncheckedDirection {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         write!(f, "{}", self.0)
     }
 }
 
-impl From<String> for NullableDirection {
+impl From<String> for UncheckedDirection {
     fn from(dir: String) -> Self {
         Self(dir)
     }
 }
 
-impl From<&str> for NullableDirection {
+impl From<&str> for UncheckedDirection {
     fn from(dir: &str) -> Self {
         dir.to_string().into()
     }
@@ -61,17 +61,17 @@ pub enum Direction {
     Forward,
 }
 
-impl From<NullableDirection> for Direction {
-    fn from(other: NullableDirection) -> Self {
+impl From<UncheckedDirection> for Direction {
+    fn from(other: UncheckedDirection) -> Self {
         match other.0.as_ref() {
-            NullableDirection::BACKWARD => Self::Backward,
-            NullableDirection::FORWARD => Self::Forward,
+            UncheckedDirection::BACKWARD => Self::Backward,
+            UncheckedDirection::FORWARD => Self::Forward,
             i => panic!("unsupported Direction: {i}"),
         }
     }
 }
 
-impl From<Direction> for NullableDirection {
+impl From<Direction> for UncheckedDirection {
     fn from(other: Direction) -> Self {
         match other {
             Direction::Backward => Self::BACKWARD.into(),

--- a/crates/mentat-types/src/models/exemption_type.rs
+++ b/crates/mentat-types/src/models/exemption_type.rs
@@ -9,9 +9,9 @@ use super::*;
 /// equal the computed balance.
 #[derive(Clone, Debug, Default, Deserialize, Serialize)]
 #[serde(transparent)]
-pub struct NullableExemptionType(String);
+pub struct UncheckedExemptionType(String);
 
-impl NullableExemptionType {
+impl UncheckedExemptionType {
     /// The live balance may increase above, decrease below, or equal the
     /// computed balance. This typically occurs with tokens that have a dynamic
     /// supply.
@@ -38,19 +38,19 @@ impl NullableExemptionType {
     }
 }
 
-impl fmt::Display for NullableExemptionType {
+impl fmt::Display for UncheckedExemptionType {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         write!(f, "{}", self.0)
     }
 }
 
-impl From<String> for NullableExemptionType {
+impl From<String> for UncheckedExemptionType {
     fn from(et: String) -> Self {
         Self(et)
     }
 }
 
-impl From<&str> for NullableExemptionType {
+impl From<&str> for UncheckedExemptionType {
     fn from(et: &str) -> Self {
         et.to_string().into()
     }
@@ -76,18 +76,18 @@ pub enum ExemptionType {
     LessOrEqual,
 }
 
-impl From<NullableExemptionType> for ExemptionType {
-    fn from(other: NullableExemptionType) -> Self {
+impl From<UncheckedExemptionType> for ExemptionType {
+    fn from(other: UncheckedExemptionType) -> Self {
         match other.0.as_ref() {
-            NullableExemptionType::DYNAMIC => Self::Dynamic,
-            NullableExemptionType::GREATER_OR_EQUAL => Self::GreaterOrEqual,
-            NullableExemptionType::LESS_OR_EQUAL => Self::LessOrEqual,
+            UncheckedExemptionType::DYNAMIC => Self::Dynamic,
+            UncheckedExemptionType::GREATER_OR_EQUAL => Self::GreaterOrEqual,
+            UncheckedExemptionType::LESS_OR_EQUAL => Self::LessOrEqual,
             i => panic!("unsupported ExemptionType: {i}"),
         }
     }
 }
 
-impl From<ExemptionType> for NullableExemptionType {
+impl From<ExemptionType> for UncheckedExemptionType {
     fn from(other: ExemptionType) -> Self {
         match other {
             ExemptionType::Dynamic => Self::DYNAMIC.into(),

--- a/crates/mentat-types/src/models/mod.rs
+++ b/crates/mentat-types/src/models/mod.rs
@@ -75,5 +75,5 @@ mod signing_payload;
 pub use signing_payload::*;
 
 mod transaction;
-pub(crate) use mentat_macros::Nullable;
+pub(crate) use mentat_macros::Unchecked;
 pub use transaction::*;

--- a/crates/mentat-types/src/models/operation.rs
+++ b/crates/mentat-types/src/models/operation.rs
@@ -16,7 +16,7 @@ pub struct NullableOperation {
     /// The [`OperationIdentifier`] uniquely identifies an operation within a
     /// transaction.
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub operation_identifier: Option<OperationIdentifier>,
+    pub operation_identifier: Option<NullableOperationIdentifier>,
     /// Restrict referenced related_operations to identifier indices " the
     /// current [`OperationIdentifier`].index. This ensures there exists a clear
     /// DAG-structure of relations. Since operations are one-sided, one could
@@ -26,7 +26,7 @@ pub struct NullableOperation {
         skip_serializing_if = "Vec::is_empty",
         deserialize_with = "null_default"
     )]
-    pub related_operations: Vec<Option<OperationIdentifier>>,
+    pub related_operations: Vec<Option<NullableOperationIdentifier>>,
     /// Type is the network-specific type of the operation. Ensure that any type
     /// that can be returned here is also specified in the
     /// [`crate::responses::NetworkOptionsResponse`]. This can be very useful to

--- a/crates/mentat-types/src/models/operation.rs
+++ b/crates/mentat-types/src/models/operation.rs
@@ -10,13 +10,13 @@ use super::*;
 /// are used both to represent on-chain data (Data API) and to construct new
 /// transactions (Construction API), creating a standard interface for reading
 /// and writing to blockchains.
-#[derive(Clone, Debug, Default, Deserialize, Serialize, PartialEq, Eq, Nullable)]
+#[derive(Clone, Debug, Default, Deserialize, Serialize, PartialEq, Eq, Unchecked)]
 #[serde(default)]
-pub struct NullableOperation {
+pub struct UncheckedOperation {
     /// The [`OperationIdentifier`] uniquely identifies an operation within a
     /// transaction.
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub operation_identifier: Option<NullableOperationIdentifier>,
+    pub operation_identifier: Option<UncheckedOperationIdentifier>,
     /// Restrict referenced related_operations to identifier indices " the
     /// current [`OperationIdentifier`].index. This ensures there exists a clear
     /// DAG-structure of relations. Since operations are one-sided, one could
@@ -26,7 +26,7 @@ pub struct NullableOperation {
         skip_serializing_if = "Vec::is_empty",
         deserialize_with = "null_default"
     )]
-    pub related_operations: Vec<Option<NullableOperationIdentifier>>,
+    pub related_operations: Vec<Option<UncheckedOperationIdentifier>>,
     /// Type is the network-specific type of the operation. Ensure that any type
     /// that can be returned here is also specified in the
     /// [`crate::responses::NetworkOptionsResponse`]. This can be very useful to
@@ -46,20 +46,20 @@ pub struct NullableOperation {
     /// (operations yet to be included on-chain have not yet succeeded or
     /// failed).
     #[serde(skip_serializing_if = "Option::is_none")]
-    #[nullable(retain)]
+    #[unchecked(retain)]
     pub status: Option<String>,
     /// The [`AccountIdentifier`] uniquely identifies an account within a
     /// network. All fields in the account_identifier are utilized to
     /// determine this uniqueness (including the metadata field, if
     /// populated).
     #[serde(skip_serializing_if = "Option::is_none")]
-    #[nullable(retain)]
+    #[unchecked(retain)]
     pub account: Option<AccountIdentifier>,
     /// [`Amount`] is some Value of a [`Currency`]. It is considered invalid to
     /// specify a Value without a [`Currency`].
     #[serde(skip_serializing_if = "Option::is_none")]
-    #[nullable(retain)]
-    pub amount: Option<NullableAmount>,
+    #[unchecked(retain)]
+    pub amount: Option<UncheckedAmount>,
     /// `CoinChange` is used to represent a change in state of a some coin
     /// identified by a coin_identifier. This object is part of the
     /// [`Operation`] model and must be populated for UTXO-based
@@ -68,8 +68,8 @@ pub struct NullableOperation {
     /// the same blockchain (when a transfer is account-based, don't
     /// populate this model).
     #[serde(skip_serializing_if = "Option::is_none")]
-    #[nullable(retain)]
-    pub coin_change: Option<NullableCoinChange>,
+    #[unchecked(retain)]
+    pub coin_change: Option<UncheckedCoinChange>,
     /// Any additional information related to the currency itself. For example,
     /// it would be useful to populate this object with the contract address of
     /// an ERC-20 token.

--- a/crates/mentat-types/src/models/operator.rs
+++ b/crates/mentat-types/src/models/operator.rs
@@ -8,9 +8,9 @@ use super::*;
 /// conditions.
 #[derive(Clone, Debug, Default, Deserialize, Serialize)]
 #[serde(transparent)]
-pub struct NullableOperator(String);
+pub struct UncheckedOperator(String);
 
-impl NullableOperator {
+impl UncheckedOperator {
     /// If all conditions are satisfied, it is considered a match.
     pub const AND: &'static str = "and";
     /// If any condition is satisfied, it is considered a match.
@@ -22,19 +22,19 @@ impl NullableOperator {
     }
 }
 
-impl fmt::Display for NullableOperator {
+impl fmt::Display for UncheckedOperator {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         write!(f, "{}", self.0)
     }
 }
 
-impl From<String> for NullableOperator {
+impl From<String> for UncheckedOperator {
     fn from(op: String) -> Self {
         Self(op)
     }
 }
 
-impl From<&str> for NullableOperator {
+impl From<&str> for UncheckedOperator {
     fn from(op: &str) -> Self {
         op.to_string().into()
     }
@@ -52,17 +52,17 @@ pub enum Operator {
     Or,
 }
 
-impl From<NullableOperator> for Operator {
-    fn from(other: NullableOperator) -> Self {
+impl From<UncheckedOperator> for Operator {
+    fn from(other: UncheckedOperator) -> Self {
         match other.0.as_ref() {
-            NullableOperator::AND => Self::And,
-            NullableOperator::OR => Self::Or,
+            UncheckedOperator::AND => Self::And,
+            UncheckedOperator::OR => Self::Or,
             i => panic!("unsupported Operator: {i}"),
         }
     }
 }
 
-impl From<Operator> for NullableOperator {
+impl From<Operator> for UncheckedOperator {
     fn from(other: Operator) -> Self {
         match other {
             Operator::And => Self::AND.into(),

--- a/crates/mentat-types/src/models/public_key.rs
+++ b/crates/mentat-types/src/models/public_key.rs
@@ -5,9 +5,9 @@ use super::*;
 /// `PublicKey` contains a public key byte array for a particular [`CurveType`]
 /// encoded in hex. Note that there is no `PrivateKey` struct as this is NEVER
 /// the concern of an implementation.
-#[derive(Clone, Debug, Deserialize, Serialize, Default, Nullable)]
+#[derive(Clone, Debug, Deserialize, Serialize, Default, Unchecked)]
 #[serde(default)]
-pub struct NullablePublicKey {
+pub struct UncheckedPublicKey {
     /// Hex-encoded public key bytes in the format specified by the
     /// [`CurveType`].
     #[serde(
@@ -16,10 +16,10 @@ pub struct NullablePublicKey {
         serialize_with = "bytes_to_hex_str",
         deserialize_with = "null_default_bytes_to_hex"
     )]
-    #[nullable(bytes)]
+    #[unchecked(bytes)]
     pub bytes: Vec<u8>,
     /// [`CurveType`] is the type of cryptographic curve associated with a
     /// PublicKey.
-    #[nullable(option_enum)]
-    pub curve_type: NullableCurveType,
+    #[unchecked(option_enum)]
+    pub curve_type: UncheckedCurveType,
 }

--- a/crates/mentat-types/src/models/related_transaction.rs
+++ b/crates/mentat-types/src/models/related_transaction.rs
@@ -5,13 +5,13 @@ use super::*;
 /// The [`RelatedTransaction`] allows implementations to link together multiple
 /// transactions. An unpopulated network identifier indicates that the related
 /// transaction is on the same network.
-#[derive(Clone, Debug, Default, Deserialize, Serialize, Nullable)]
+#[derive(Clone, Debug, Default, Deserialize, Serialize, Unchecked)]
 #[serde(default)]
-pub struct NullableRelatedTransaction {
+pub struct UncheckedRelatedTransaction {
     /// The [`NetworkIdentifier`] specifies which network a particular object is
     /// associated with.
     #[serde(skip_serializing_if = "Option::is_none")]
-    #[nullable(retain)]
+    #[unchecked(retain)]
     pub network_identifier: Option<NetworkIdentifier>,
     /// The [`TransactionIdentifier`] uniquely identifies a transaction in a
     /// particular network and block or in the mempool.
@@ -22,11 +22,11 @@ pub struct NullableRelatedTransaction {
     /// backward to an earlier transaction and async execution may reference
     /// forward). Can be used to indicate if a transaction relation is from
     /// child to parent or the reverse.
-    #[nullable(option_enum)]
-    pub direction: NullableDirection,
+    #[unchecked(option_enum)]
+    pub direction: UncheckedDirection,
 }
 
-impl Sortable for NullableRelatedTransaction {
+impl Sortable for UncheckedRelatedTransaction {
     fn sort(&self) -> Self {
         let mut new = self.clone();
         new.network_identifier = new.network_identifier.map(|ni| ni.sort());

--- a/crates/mentat-types/src/models/signature.rs
+++ b/crates/mentat-types/src/models/signature.rs
@@ -7,23 +7,23 @@ use super::*;
 /// the SignatureType. [`PublicKey`] is often times not known during
 /// construction of the signing payloads but may be needed to combine signatures
 /// properly.
-#[derive(Debug, Deserialize, Serialize, Default, Nullable)]
+#[derive(Debug, Deserialize, Serialize, Default, Unchecked)]
 #[serde(default)]
-pub struct NullableSignature {
+pub struct UncheckedSignature {
     /// [`SigningPayload`] is signed by the client with the keypair associated
     /// with an AccountIdentifier using the specified [`SignatureType`].
     /// [`SignatureType`] can be optionally populated if there is a restriction
     /// on the signature scheme that can be used to sign the payload.
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub signing_payload: Option<NullableSigningPayload>,
+    pub signing_payload: Option<UncheckedSigningPayload>,
     /// [`PublicKey`] contains a public key byte array for a particular
     /// CurveType encoded in hex. Note that there is no `PrivateKey` struct as
     /// this is NEVER the concern of an implementation.
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub public_key: Option<NullablePublicKey>,
+    pub public_key: Option<UncheckedPublicKey>,
     /// [`SignatureType`] is the type of a cryptographic signature.
-    #[nullable(option_enum)]
-    pub signature_type: NullableSignatureType,
+    #[unchecked(option_enum)]
+    pub signature_type: UncheckedSignatureType,
     /// The hex bytes for the `Signature`.
     #[serde(
         rename = "hex_bytes",
@@ -31,6 +31,6 @@ pub struct NullableSignature {
         serialize_with = "bytes_to_hex_str",
         deserialize_with = "null_default_bytes_to_hex"
     )]
-    #[nullable(bytes)]
+    #[unchecked(bytes)]
     pub bytes: Vec<u8>,
 }

--- a/crates/mentat-types/src/models/signature_type.rs
+++ b/crates/mentat-types/src/models/signature_type.rs
@@ -7,9 +7,9 @@ use super::*;
 /// OperatorSignatureType is the type of a cryptographic signature.
 #[derive(Clone, Debug, Default, Deserialize, Serialize, PartialEq, Eq)]
 #[serde(transparent)]
-pub struct NullableSignatureType(String);
+pub struct UncheckedSignatureType(String);
 
-impl NullableSignatureType {
+impl UncheckedSignatureType {
     /// r (32-bytes) + s (32-bytes)
     pub const ECDSA: &'static str = "ecdsa";
     /// r (32-bytes) + s (32-bytes) + v (1-byte)
@@ -39,19 +39,19 @@ impl NullableSignatureType {
     }
 }
 
-impl fmt::Display for NullableSignatureType {
+impl fmt::Display for UncheckedSignatureType {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         write!(f, "{}", self.0)
     }
 }
 
-impl From<String> for NullableSignatureType {
+impl From<String> for UncheckedSignatureType {
     fn from(st: String) -> Self {
         Self(st)
     }
 }
 
-impl From<&str> for NullableSignatureType {
+impl From<&str> for UncheckedSignatureType {
     fn from(st: &str) -> Self {
         st.to_string().into()
     }
@@ -75,20 +75,20 @@ pub enum SignatureType {
     EchnorrPoseidon,
 }
 
-impl From<NullableSignatureType> for SignatureType {
-    fn from(other: NullableSignatureType) -> Self {
+impl From<UncheckedSignatureType> for SignatureType {
+    fn from(other: UncheckedSignatureType) -> Self {
         match other.0.as_ref() {
-            NullableSignatureType::ECDSA => Self::Ecdsa,
-            NullableSignatureType::ECDSA_RECOVERY => Self::EcdsaRecovery,
-            NullableSignatureType::ED25519 => Self::Ed25519,
-            NullableSignatureType::SCHNORR_1 => Self::Schnorr1,
-            NullableSignatureType::SCHNORR_POSEIDON => Self::EchnorrPoseidon,
+            UncheckedSignatureType::ECDSA => Self::Ecdsa,
+            UncheckedSignatureType::ECDSA_RECOVERY => Self::EcdsaRecovery,
+            UncheckedSignatureType::ED25519 => Self::Ed25519,
+            UncheckedSignatureType::SCHNORR_1 => Self::Schnorr1,
+            UncheckedSignatureType::SCHNORR_POSEIDON => Self::EchnorrPoseidon,
             i => panic!("unsupported ExemptionType: {i}"),
         }
     }
 }
 
-impl From<SignatureType> for NullableSignatureType {
+impl From<SignatureType> for UncheckedSignatureType {
     fn from(other: SignatureType) -> Self {
         match other {
             SignatureType::Ecdsa => Self::ECDSA.into(),

--- a/crates/mentat-types/src/models/signing_payload.rs
+++ b/crates/mentat-types/src/models/signing_payload.rs
@@ -4,33 +4,33 @@ use serde::ser::SerializeStruct;
 
 use super::*;
 
-// TODO add `#[nullable(skip_serde)]` and copy paste serde impls for
-// non-nullable struct
+// TODO add `#[unchecked(skip_serde)]` and copy paste serde impls for
+// non-unchecked struct
 /// [`SigningPayload`] is signed by the client with the keypair associated with
 /// an [`AccountIdentifier`] using the specified [`SignatureType`].
 /// [`SignatureType`] can be optionally populated if there is a restriction on
 /// the signature scheme that can be used to sign the payload.
-#[derive(Clone, Debug, Default, PartialEq, Eq, Nullable)]
-pub struct NullableSigningPayload {
+#[derive(Clone, Debug, Default, PartialEq, Eq, Unchecked)]
+pub struct UncheckedSigningPayload {
     /// [DEPRECATED by account_identifier in v1.4.4] The network-specific
     /// address of the account that should sign the payload.
-    #[nullable(retain)]
+    #[unchecked(retain)]
     pub address: Option<String>,
     /// The `AccountIdentifier` uniquely identifies an account within a
     /// network. All fields in the account_identifier are utilized to
     /// determine this uniqueness (including the metadata field, if
     /// populated).
-    #[nullable(retain)]
+    #[unchecked(retain)]
     pub account_identifier: Option<AccountIdentifier>,
     /// The hex bytes of the Signing Payload.
-    #[nullable(bytes)]
+    #[unchecked(bytes)]
     pub bytes: Vec<u8>,
     /// `SignatureType` is the type of a cryptographic signature.
-    #[nullable(option_enum)]
-    pub signature_type: NullableSignatureType,
+    #[unchecked(option_enum)]
+    pub signature_type: UncheckedSignatureType,
 }
 
-impl Serialize for NullableSigningPayload {
+impl Serialize for UncheckedSigningPayload {
     fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
     where
         S: serde::Serializer,
@@ -67,10 +67,10 @@ struct SigningPayloadPre {
         deserialize_with = "null_default_bytes_to_hex"
     )]
     pub bytes: Vec<u8>,
-    pub signature_type: NullableSignatureType,
+    pub signature_type: UncheckedSignatureType,
 }
 
-impl<'de> Deserialize<'de> for NullableSigningPayload {
+impl<'de> Deserialize<'de> for UncheckedSigningPayload {
     fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
     where
         D: serde::Deserializer<'de>,
@@ -86,7 +86,7 @@ impl<'de> Deserialize<'de> for NullableSigningPayload {
             })
         };
 
-        Ok(NullableSigningPayload {
+        Ok(UncheckedSigningPayload {
             address: None,
             account_identifier,
             bytes: pre.bytes,

--- a/crates/mentat-types/src/models/transaction.rs
+++ b/crates/mentat-types/src/models/transaction.rs
@@ -6,9 +6,9 @@ use super::*;
 
 /// [`Transaction`]s contain an array of [`Operation`]s that are attributable to
 /// the same [`TransactionIdentifier`].
-#[derive(Clone, Debug, Default, Deserialize, Serialize, Nullable)]
+#[derive(Clone, Debug, Default, Deserialize, Serialize, Unchecked)]
 #[serde(default)]
-pub struct NullableTransaction {
+pub struct UncheckedTransaction {
     /// The [`TransactionIdentifier`] uniquely identifies a transaction in a
     /// particular network and block or in the mempool.
     #[serde(skip_serializing_if = "Option::is_none")]
@@ -18,13 +18,13 @@ pub struct NullableTransaction {
         skip_serializing_if = "Vec::is_empty",
         deserialize_with = "null_default"
     )]
-    pub operations: Vec<Option<NullableOperation>>,
+    pub operations: Vec<Option<UncheckedOperation>>,
     /// A optional list of `RelatedTransaction` related to this transaction.
     #[serde(
         skip_serializing_if = "Vec::is_empty",
         deserialize_with = "null_default"
     )]
-    pub related_transactions: Vec<Option<NullableRelatedTransaction>>,
+    pub related_transactions: Vec<Option<UncheckedRelatedTransaction>>,
     /// `Transaction`s that are related to other transactions (like a
     /// cross-shard transaction) should include the tranaction_identifier of
     /// these transactions in the metadata.

--- a/crates/mentat-types/src/requests/account_balance.rs
+++ b/crates/mentat-types/src/requests/account_balance.rs
@@ -5,9 +5,9 @@ use super::*;
 /// An `AccountBalanceRequest` is utilized to make a balance request on the
 /// `/account/balance` endpoint. If the `block_identifier` is populated, a
 /// historical balance query should be performed.
-#[derive(Debug, Default, Deserialize, Serialize, Nullable)]
+#[derive(Debug, Default, Deserialize, Serialize, Unchecked)]
 #[serde(default)]
-pub struct NullableAccountBalanceRequest {
+pub struct UncheckedAccountBalanceRequest {
     /// The `NetworkIdentifier` specifies which network a particular object is
     /// associated with.
     #[serde(skip_serializing_if = "Option::is_none")]
@@ -22,8 +22,8 @@ pub struct NullableAccountBalanceRequest {
     /// specify the index or hash. If neither property is specified, it is
     /// assumed that the client is making a request at the current block.
     #[serde(skip_serializing_if = "Option::is_none")]
-    #[nullable(retain)]
-    pub block_identifier: Option<NullablePartialBlockIdentifier>,
+    #[unchecked(retain)]
+    pub block_identifier: Option<UncheckedPartialBlockIdentifier>,
     /// In some cases, the caller may not want to retrieve all available
     /// balances for an [`AccountIdentifier`]. If the currencies field is
     /// populated, only balances for the specified currencies will be
@@ -32,5 +32,5 @@ pub struct NullableAccountBalanceRequest {
         skip_serializing_if = "Vec::is_empty",
         deserialize_with = "null_default"
     )]
-    pub currencies: Vec<Option<NullableCurrency>>,
+    pub currencies: Vec<Option<UncheckedCurrency>>,
 }

--- a/crates/mentat-types/src/requests/account_balance.rs
+++ b/crates/mentat-types/src/requests/account_balance.rs
@@ -23,7 +23,7 @@ pub struct NullableAccountBalanceRequest {
     /// assumed that the client is making a request at the current block.
     #[serde(skip_serializing_if = "Option::is_none")]
     #[nullable(retain)]
-    pub block_identifier: Option<PartialBlockIdentifier>,
+    pub block_identifier: Option<NullablePartialBlockIdentifier>,
     /// In some cases, the caller may not want to retrieve all available
     /// balances for an [`AccountIdentifier`]. If the currencies field is
     /// populated, only balances for the specified currencies will be

--- a/crates/mentat-types/src/requests/account_coins.rs
+++ b/crates/mentat-types/src/requests/account_coins.rs
@@ -4,9 +4,9 @@ use super::*;
 
 /// `AccountCoinsRequest` is utilized to make a request on the `/account/coins`
 /// endpoint.
-#[derive(Debug, Default, Deserialize, Serialize, Nullable)]
+#[derive(Debug, Default, Deserialize, Serialize, Unchecked)]
 #[serde(default)]
-pub struct NullableAccountCoinsRequest {
+pub struct UncheckedAccountCoinsRequest {
     /// The `NetworkIdentifier` specifies which network a particular object is
     /// associated with.
     #[serde(skip_serializing_if = "Option::is_none")]
@@ -29,5 +29,5 @@ pub struct NullableAccountCoinsRequest {
         skip_serializing_if = "Vec::is_empty",
         deserialize_with = "null_default"
     )]
-    pub currencies: Vec<Option<NullableCurrency>>,
+    pub currencies: Vec<Option<UncheckedCurrency>>,
 }

--- a/crates/mentat-types/src/requests/block.rs
+++ b/crates/mentat-types/src/requests/block.rs
@@ -4,9 +4,9 @@ use super::*;
 
 /// A [`BlockRequest`] is utilized to make a block request on the `/block`
 /// endpoint.
-#[derive(Debug, Default, Deserialize, Serialize, Nullable)]
+#[derive(Debug, Default, Deserialize, Serialize, Unchecked)]
 #[serde(default)]
-pub struct NullableBlockRequest {
+pub struct UncheckedBlockRequest {
     /// The [`NetworkIdentifier`] specifies which network a particular object is
     /// associated with.
     #[serde(skip_serializing_if = "Option::is_none")]
@@ -16,12 +16,15 @@ pub struct NullableBlockRequest {
     /// assumed that the client is making a request at the current block.
     /// This is represented via a [`PartialBlockIdentifier`].
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub block_identifier: Option<NullablePartialBlockIdentifier>,
+    pub block_identifier: Option<UncheckedPartialBlockIdentifier>,
 }
 
-impl From<(NetworkIdentifier, NullablePartialBlockIdentifier)> for NullableBlockRequest {
+impl From<(NetworkIdentifier, UncheckedPartialBlockIdentifier)> for UncheckedBlockRequest {
     fn from(
-        (network_identifier, block_identifier): (NetworkIdentifier, NullablePartialBlockIdentifier),
+        (network_identifier, block_identifier): (
+            NetworkIdentifier,
+            UncheckedPartialBlockIdentifier,
+        ),
     ) -> Self {
         Self {
             network_identifier: Some(network_identifier),
@@ -30,9 +33,12 @@ impl From<(NetworkIdentifier, NullablePartialBlockIdentifier)> for NullableBlock
     }
 }
 
-impl From<(NullablePartialBlockIdentifier, NetworkIdentifier)> for NullableBlockRequest {
+impl From<(UncheckedPartialBlockIdentifier, NetworkIdentifier)> for UncheckedBlockRequest {
     fn from(
-        (block_identifier, network_identifier): (NullablePartialBlockIdentifier, NetworkIdentifier),
+        (block_identifier, network_identifier): (
+            UncheckedPartialBlockIdentifier,
+            NetworkIdentifier,
+        ),
     ) -> Self {
         Self {
             network_identifier: Some(network_identifier),

--- a/crates/mentat-types/src/requests/block.rs
+++ b/crates/mentat-types/src/requests/block.rs
@@ -16,12 +16,12 @@ pub struct NullableBlockRequest {
     /// assumed that the client is making a request at the current block.
     /// This is represented via a [`PartialBlockIdentifier`].
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub block_identifier: Option<PartialBlockIdentifier>,
+    pub block_identifier: Option<NullablePartialBlockIdentifier>,
 }
 
-impl From<(NetworkIdentifier, PartialBlockIdentifier)> for NullableBlockRequest {
+impl From<(NetworkIdentifier, NullablePartialBlockIdentifier)> for NullableBlockRequest {
     fn from(
-        (network_identifier, block_identifier): (NetworkIdentifier, PartialBlockIdentifier),
+        (network_identifier, block_identifier): (NetworkIdentifier, NullablePartialBlockIdentifier),
     ) -> Self {
         Self {
             network_identifier: Some(network_identifier),
@@ -30,9 +30,9 @@ impl From<(NetworkIdentifier, PartialBlockIdentifier)> for NullableBlockRequest 
     }
 }
 
-impl From<(PartialBlockIdentifier, NetworkIdentifier)> for NullableBlockRequest {
+impl From<(NullablePartialBlockIdentifier, NetworkIdentifier)> for NullableBlockRequest {
     fn from(
-        (block_identifier, network_identifier): (PartialBlockIdentifier, NetworkIdentifier),
+        (block_identifier, network_identifier): (NullablePartialBlockIdentifier, NetworkIdentifier),
     ) -> Self {
         Self {
             network_identifier: Some(network_identifier),

--- a/crates/mentat-types/src/requests/block_transaction.rs
+++ b/crates/mentat-types/src/requests/block_transaction.rs
@@ -16,20 +16,24 @@ pub struct NullableBlockTransactionRequest {
     /// The [`BlockIdentifier`] uniquely identifies a block in a particular
     /// network.
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub block_identifier: Option<BlockIdentifier>,
+    pub block_identifier: Option<NullableBlockIdentifier>,
     /// The [`TransactionIdentifier`] uniquely identifies a transaction in a
     /// particular network and block or in the mempool.
     #[serde(skip_serializing_if = "Option::is_none")]
     pub transaction_identifier: Option<TransactionIdentifier>,
 }
 
-impl From<(NetworkIdentifier, BlockIdentifier, TransactionIdentifier)>
-    for NullableBlockTransactionRequest
+impl
+    From<(
+        NetworkIdentifier,
+        NullableBlockIdentifier,
+        TransactionIdentifier,
+    )> for NullableBlockTransactionRequest
 {
     fn from(
         (network_identifier, block_identifier, transaction_identifier): (
             NetworkIdentifier,
-            BlockIdentifier,
+            NullableBlockIdentifier,
             TransactionIdentifier,
         ),
     ) -> Self {

--- a/crates/mentat-types/src/requests/block_transaction.rs
+++ b/crates/mentat-types/src/requests/block_transaction.rs
@@ -6,9 +6,9 @@ use super::*;
 
 /// A [`BlockRequest`] is utilized to make a block request on the `/block`
 /// endpoint.
-#[derive(Debug, Default, Deserialize, FromTuple, Serialize, Nullable)]
+#[derive(Debug, Default, Deserialize, FromTuple, Serialize, Unchecked)]
 #[serde(default)]
-pub struct NullableBlockTransactionRequest {
+pub struct UncheckedBlockTransactionRequest {
     /// The [`NetworkIdentifier`] specifies which network a particular object is
     /// associated with.
     #[serde(skip_serializing_if = "Option::is_none")]
@@ -16,7 +16,7 @@ pub struct NullableBlockTransactionRequest {
     /// The [`BlockIdentifier`] uniquely identifies a block in a particular
     /// network.
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub block_identifier: Option<NullableBlockIdentifier>,
+    pub block_identifier: Option<UncheckedBlockIdentifier>,
     /// The [`TransactionIdentifier`] uniquely identifies a transaction in a
     /// particular network and block or in the mempool.
     #[serde(skip_serializing_if = "Option::is_none")]
@@ -26,14 +26,14 @@ pub struct NullableBlockTransactionRequest {
 impl
     From<(
         NetworkIdentifier,
-        NullableBlockIdentifier,
+        UncheckedBlockIdentifier,
         TransactionIdentifier,
-    )> for NullableBlockTransactionRequest
+    )> for UncheckedBlockTransactionRequest
 {
     fn from(
         (network_identifier, block_identifier, transaction_identifier): (
             NetworkIdentifier,
-            NullableBlockIdentifier,
+            UncheckedBlockIdentifier,
             TransactionIdentifier,
         ),
     ) -> Self {

--- a/crates/mentat-types/src/requests/call.rs
+++ b/crates/mentat-types/src/requests/call.rs
@@ -5,9 +5,9 @@ use indexmap::IndexMap;
 use super::*;
 
 /// `CallRequest` is the input to the `/call` endpoint.
-#[derive(Debug, Default, Deserialize, Serialize, Nullable)]
+#[derive(Debug, Default, Deserialize, Serialize, Unchecked)]
 #[serde(default)]
-pub struct NullableCallRequest {
+pub struct UncheckedCallRequest {
     /// The [`NetworkIdentifier`] specifies which network a particular object is
     /// associated with.
     #[serde(skip_serializing_if = "Option::is_none")]

--- a/crates/mentat-types/src/requests/construction_combine.rs
+++ b/crates/mentat-types/src/requests/construction_combine.rs
@@ -6,9 +6,9 @@ use super::*;
 /// endpoint. It contains the unsigned transaction blob returned by
 /// `/construction/payloads` and all required signatures to create a network
 /// transaction.
-#[derive(Debug, Default, Deserialize, Serialize, Nullable)]
+#[derive(Debug, Default, Deserialize, Serialize, Unchecked)]
 #[serde(default)]
-pub struct NullableConstructionCombineRequest {
+pub struct UncheckedConstructionCombineRequest {
     /// The [`NetworkIdentifier`] specifies which network a particular object is
     /// associated with.
     #[serde(skip_serializing_if = "Option::is_none")]
@@ -20,5 +20,5 @@ pub struct NullableConstructionCombineRequest {
         skip_serializing_if = "Vec::is_empty",
         deserialize_with = "null_default"
     )]
-    pub signatures: Vec<Option<NullableSignature>>,
+    pub signatures: Vec<Option<UncheckedSignature>>,
 }

--- a/crates/mentat-types/src/requests/construction_derive.rs
+++ b/crates/mentat-types/src/requests/construction_derive.rs
@@ -9,9 +9,9 @@ use super::*;
 /// different address formats for different networks. `Metadata` is provided in
 /// the request because some blockchains allow for multiple address types (i.e.
 /// different address for validators vs normal accounts).
-#[derive(Debug, Deserialize, Serialize, Default, Nullable)]
+#[derive(Debug, Deserialize, Serialize, Default, Unchecked)]
 #[serde(default)]
-pub struct NullableConstructionDeriveRequest {
+pub struct UncheckedConstructionDeriveRequest {
     /// The [`NetworkIdentifier`] specifies which network a particular object is
     /// associated with.
     #[serde(skip_serializing_if = "Option::is_none")]
@@ -20,7 +20,7 @@ pub struct NullableConstructionDeriveRequest {
     /// [`CurveType`] encoded in hex. Note that there is no `PrivateKey`
     /// struct as this is NEVER the concern of an implementation.
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub public_key: Option<NullablePublicKey>,
+    pub public_key: Option<UncheckedPublicKey>,
     #[allow(clippy::missing_docs_in_private_items)]
     pub metadata: IndexMap<String, Value>,
 }

--- a/crates/mentat-types/src/requests/construction_hash.rs
+++ b/crates/mentat-types/src/requests/construction_hash.rs
@@ -4,9 +4,9 @@ use super::*;
 
 /// [`ConstructionHashRequest`] is the input to the `/construction/hash`
 /// endpoint.
-#[derive(Clone, Debug, Deserialize, Serialize, Default, Nullable)]
+#[derive(Clone, Debug, Deserialize, Serialize, Default, Unchecked)]
 #[serde(default)]
-pub struct NullableConstructionHashRequest {
+pub struct UncheckedConstructionHashRequest {
     /// The [`NetworkIdentifier`] specifies which network a particular object is
     /// associated with.
     #[serde(skip_serializing_if = "Option::is_none")]

--- a/crates/mentat-types/src/requests/construction_metadata.rs
+++ b/crates/mentat-types/src/requests/construction_metadata.rs
@@ -10,8 +10,8 @@ use super::*;
 /// an array of [`PublicKey`]s associated with the [`Account
 /// #[serde(default)]Identifier`]s
 /// returned in [`crate::responses::ConstructionPreprocessResponse`].
-#[derive(Clone, Debug, Deserialize, Serialize, Default, Nullable)]
-pub struct NullableConstructionMetadataRequest {
+#[derive(Clone, Debug, Deserialize, Serialize, Default, Unchecked)]
+pub struct UncheckedConstructionMetadataRequest {
     /// The [`NetworkIdentifier`] specifies which network a particular object is
     /// associated with.
     #[serde(skip_serializing_if = "Option::is_none")]
@@ -23,12 +23,12 @@ pub struct NullableConstructionMetadataRequest {
     /// populate an options object to limit the metadata returned to only the
     /// subset required.
     #[serde(skip_serializing_if = "Option::is_none")]
-    #[nullable(retain)]
+    #[unchecked(retain)]
     pub options: Option<Value>,
     #[allow(clippy::missing_docs_in_private_items)]
     #[serde(
         skip_serializing_if = "Vec::is_empty",
         deserialize_with = "null_default"
     )]
-    pub public_keys: Vec<Option<NullablePublicKey>>,
+    pub public_keys: Vec<Option<UncheckedPublicKey>>,
 }

--- a/crates/mentat-types/src/requests/construction_parse.rs
+++ b/crates/mentat-types/src/requests/construction_parse.rs
@@ -5,9 +5,9 @@ use super::*;
 /// [`ConstructionParseRequest`] is the input to the `/construction/parse`
 /// endpoint. It allows the caller to parse either an unsigned or signed
 /// transaction.
-#[derive(Clone, Debug, Deserialize, Serialize, Default, Nullable)]
+#[derive(Clone, Debug, Deserialize, Serialize, Default, Unchecked)]
 #[serde(default)]
-pub struct NullableConstructionParseRequest {
+pub struct UncheckedConstructionParseRequest {
     /// The [`NetworkIdentifier`] specifies which network a particular object is
     /// associated with.
     #[serde(skip_serializing_if = "Option::is_none")]

--- a/crates/mentat-types/src/requests/construction_payloads.rs
+++ b/crates/mentat-types/src/requests/construction_payloads.rs
@@ -10,9 +10,9 @@ use super::*;
 /// request can also include an array of [`PublicKey`]s associated with the
 /// [`AccountIdentifier`]s returned in
 /// [`crate::responses::ConstructionPreprocessResponse`].
-#[derive(Clone, Debug, Deserialize, Serialize, Default, Nullable)]
+#[derive(Clone, Debug, Deserialize, Serialize, Default, Unchecked)]
 #[serde(default)]
-pub struct NullableConstructionPayloadsRequest {
+pub struct UncheckedConstructionPayloadsRequest {
     /// The [`NetworkIdentifier`] specifies which network a particular object is
     /// associated with.
     #[serde(skip_serializing_if = "Option::is_none")]
@@ -22,15 +22,15 @@ pub struct NullableConstructionPayloadsRequest {
         skip_serializing_if = "Vec::is_empty",
         deserialize_with = "null_default"
     )]
-    pub operations: Vec<Option<NullableOperation>>,
+    pub operations: Vec<Option<UncheckedOperation>>,
     #[allow(clippy::missing_docs_in_private_items)]
     #[serde(skip_serializing_if = "IndexMap::is_empty")]
-    #[nullable(retain)]
+    #[unchecked(retain)]
     pub metadata: IndexMap<String, Value>,
     #[allow(clippy::missing_docs_in_private_items)]
     #[serde(
         skip_serializing_if = "Vec::is_empty",
         deserialize_with = "null_default"
     )]
-    pub public_keys: Vec<Option<NullablePublicKey>>,
+    pub public_keys: Vec<Option<UncheckedPublicKey>>,
 }

--- a/crates/mentat-types/src/requests/construction_preprocess.rs
+++ b/crates/mentat-types/src/requests/construction_preprocess.rs
@@ -6,7 +6,7 @@ use super::*;
 
 #[derive(Clone, Debug, Deserialize, Serialize, Default)]
 #[serde(default)]
-pub struct NullableConstructionPreprocessRequest {
+pub struct UncheckedConstructionPreprocessRequest {
     #[serde(skip_serializing_if = "Option::is_none")]
     pub network_identifier: Option<NetworkIdentifier>,
     #[allow(clippy::missing_docs_in_private_items)]
@@ -14,7 +14,7 @@ pub struct NullableConstructionPreprocessRequest {
         skip_serializing_if = "Vec::is_empty",
         deserialize_with = "null_default"
     )]
-    pub operations: Vec<Option<NullableOperation>>,
+    pub operations: Vec<Option<UncheckedOperation>>,
     #[allow(clippy::missing_docs_in_private_items)]
     #[serde(skip_serializing_if = "IndexMap::is_empty")]
     pub metadata: IndexMap<String, Value>,
@@ -23,7 +23,7 @@ pub struct NullableConstructionPreprocessRequest {
         skip_serializing_if = "Vec::is_empty",
         deserialize_with = "null_default"
     )]
-    pub max_fee: Vec<Option<NullableAmount>>,
+    pub max_fee: Vec<Option<UncheckedAmount>>,
     #[allow(clippy::missing_docs_in_private_items)]
     #[serde(skip_serializing_if = "Option::is_none")]
     pub suggested_fee_multiplier: Option<f64>,
@@ -72,22 +72,22 @@ pub struct ConstructionPreprocessRequest {
     pub suggested_fee_multiplier: Option<f64>,
 }
 
-impl From<NullableConstructionPreprocessRequest> for ConstructionPreprocessRequest {
-    fn from(nullable: NullableConstructionPreprocessRequest) -> Self {
+impl From<UncheckedConstructionPreprocessRequest> for ConstructionPreprocessRequest {
+    fn from(unchecked: UncheckedConstructionPreprocessRequest) -> Self {
         Self {
-            network_identifier: nullable.network_identifier.unwrap(),
-            operations: nullable
+            network_identifier: unchecked.network_identifier.unwrap(),
+            operations: unchecked
                 .operations
                 .into_iter()
                 .map(|op| op.unwrap().into())
                 .collect(),
-            metadata: nullable.metadata,
-            max_fee: nullable
+            metadata: unchecked.metadata,
+            max_fee: unchecked
                 .max_fee
                 .into_iter()
                 .map(|fee| fee.unwrap().into())
                 .collect(),
-            suggested_fee_multiplier: nullable.suggested_fee_multiplier,
+            suggested_fee_multiplier: unchecked.suggested_fee_multiplier,
         }
     }
 }

--- a/crates/mentat-types/src/requests/construction_submit.rs
+++ b/crates/mentat-types/src/requests/construction_submit.rs
@@ -3,9 +3,9 @@
 use super::*;
 
 /// The transaction submission request includes a signed transaction.
-#[derive(Clone, Debug, Deserialize, Serialize, Default, Nullable)]
+#[derive(Clone, Debug, Deserialize, Serialize, Default, Unchecked)]
 #[serde(default)]
-pub struct NullableConstructionSubmitRequest {
+pub struct UncheckedConstructionSubmitRequest {
     /// The [`NetworkIdentifier`] specifies which network a particular object is
     /// associated with.
     #[serde(skip_serializing_if = "Option::is_none")]

--- a/crates/mentat-types/src/requests/event_blocks.rs
+++ b/crates/mentat-types/src/requests/event_blocks.rs
@@ -3,9 +3,9 @@
 use super::*;
 
 /// The transaction submission request includes a signed transaction.
-#[derive(Clone, Debug, Deserialize, Serialize, Default, Nullable)]
+#[derive(Clone, Debug, Deserialize, Serialize, Default, Unchecked)]
 #[serde(default)]
-pub struct NullableEventsBlocksRequest {
+pub struct UncheckedEventsBlocksRequest {
     /// [`EventsBlocksRequest`] is utilized to fetch a sequence of
     /// [`BlockEvent`]s indicating which blocks were added and removed from
     /// storage to reach the current state.
@@ -15,11 +15,11 @@ pub struct NullableEventsBlocksRequest {
     /// field is not populated, we return the limit events backwards from tip.
     /// If this is set to 0, we start from the beginning.
     #[serde(skip_serializing_if = "Option::is_none")]
-    #[nullable(option_usize)]
+    #[unchecked(option_usize)]
     pub offset: Option<isize>,
     /// limit is the maximum number of events to fetch in one call. The
     /// implementation may return "= limit events.
     #[serde(skip_serializing_if = "Option::is_none")]
-    #[nullable(option_usize)]
+    #[unchecked(option_usize)]
     pub limit: Option<isize>,
 }

--- a/crates/mentat-types/src/requests/event_blocks.rs
+++ b/crates/mentat-types/src/requests/event_blocks.rs
@@ -15,11 +15,11 @@ pub struct NullableEventsBlocksRequest {
     /// field is not populated, we return the limit events backwards from tip.
     /// If this is set to 0, we start from the beginning.
     #[serde(skip_serializing_if = "Option::is_none")]
-    #[nullable(retain)]
-    pub offset: Option<i64>,
+    #[nullable(option_usize)]
+    pub offset: Option<isize>,
     /// limit is the maximum number of events to fetch in one call. The
     /// implementation may return "= limit events.
     #[serde(skip_serializing_if = "Option::is_none")]
-    #[nullable(retain)]
-    pub limit: Option<i64>,
+    #[nullable(option_usize)]
+    pub limit: Option<isize>,
 }

--- a/crates/mentat-types/src/requests/mempool_transaction.rs
+++ b/crates/mentat-types/src/requests/mempool_transaction.rs
@@ -5,9 +5,9 @@ use from_tuple::FromTuple;
 use super::*;
 
 /// The transaction submission request includes a signed transaction.
-#[derive(Clone, Debug, Default, Deserialize, FromTuple, Serialize, Nullable)]
+#[derive(Clone, Debug, Default, Deserialize, FromTuple, Serialize, Unchecked)]
 #[serde(default)]
-pub struct NullableMempoolTransactionRequest {
+pub struct UncheckedMempoolTransactionRequest {
     /// [`EventsBlocksRequest`] is utilized to fetch a sequence of
     /// [`BlockEvent`]s indicating which blocks were added and removed from
     /// storage to reach the current state.
@@ -19,7 +19,7 @@ pub struct NullableMempoolTransactionRequest {
     pub transaction_identifier: Option<TransactionIdentifier>,
 }
 
-impl From<(NetworkIdentifier, TransactionIdentifier)> for NullableMempoolTransactionRequest {
+impl From<(NetworkIdentifier, TransactionIdentifier)> for UncheckedMempoolTransactionRequest {
     fn from(
         (network_identifier, transaction_identifier): (NetworkIdentifier, TransactionIdentifier),
     ) -> Self {

--- a/crates/mentat-types/src/requests/metadata.rs
+++ b/crates/mentat-types/src/requests/metadata.rs
@@ -6,9 +6,9 @@ use super::*;
 
 /// A `MetadataRequest` is utilized in any request where the only argument is
 /// optional metadata.
-#[derive(Clone, Debug, Default, Deserialize, Serialize, Nullable)]
+#[derive(Clone, Debug, Default, Deserialize, Serialize, Unchecked)]
 #[serde(default)]
-pub struct NullableMetadataRequest {
+pub struct UncheckedMetadataRequest {
     #[allow(clippy::missing_docs_in_private_items)]
     #[serde(skip_serializing_if = "IndexMap::is_empty")]
     pub metadata: IndexMap<String, Value>,

--- a/crates/mentat-types/src/requests/network.rs
+++ b/crates/mentat-types/src/requests/network.rs
@@ -6,9 +6,9 @@ use super::*;
 
 /// A [`NetworkRequest`] is utilized to retrieve some data specific exclusively
 /// to a [`NetworkIdentifier`].
-#[derive(Clone, Debug, Default, Deserialize, Serialize, Nullable)]
+#[derive(Clone, Debug, Default, Deserialize, Serialize, Unchecked)]
 #[serde(default)]
-pub struct NullableNetworkRequest {
+pub struct UncheckedNetworkRequest {
     /// The [`NetworkIdentifier`] specifies which network a particular object is
     /// associated with.
     #[serde(skip_serializing_if = "Option::is_none")]
@@ -17,7 +17,7 @@ pub struct NullableNetworkRequest {
     pub metadata: IndexMap<String, Value>,
 }
 
-impl From<NetworkIdentifier> for NullableNetworkRequest {
+impl From<NetworkIdentifier> for UncheckedNetworkRequest {
     fn from(net: NetworkIdentifier) -> Self {
         Self {
             network_identifier: Some(net),

--- a/crates/mentat-types/src/requests/search_transactions.rs
+++ b/crates/mentat-types/src/requests/search_transactions.rs
@@ -4,9 +4,9 @@ use super::*;
 
 /// [`SearchTransactionsRequest`] is used to search for transactions matching a
 /// set of provided conditions in canonical blocks.
-#[derive(Clone, Debug, Deserialize, Serialize, Default, Nullable)]
+#[derive(Clone, Debug, Deserialize, Serialize, Default, Unchecked)]
 #[serde(default)]
-pub struct NullableSearchTransactionsRequest {
+pub struct UncheckedSearchTransactionsRequest {
     /// The [`NetworkIdentifier`] specifies which network a particular object is
     /// associated with.
     #[serde(skip_serializing_if = "Option::is_none")]
@@ -15,64 +15,64 @@ pub struct NullableSearchTransactionsRequest {
     /// conditions. If this field is not populated, the default and value will
     /// be used.
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub operator: Option<NullableOperator>,
+    pub operator: Option<UncheckedOperator>,
     /// `max_block` is the largest block index to consider when searching for
     /// transactions. If this field is not populated, the current block is
     /// considered the `max_block`. If you do not specify a `max_block`, it is
     /// possible a newly synced block will interfere with paginated transaction
     /// queries (as the offset could become invalid with newly added rows).
     #[serde(skip_serializing_if = "Option::is_none")]
-    #[nullable(option_usize)]
+    #[unchecked(option_usize)]
     pub max_block: Option<isize>,
     /// offset is the offset into the query result to start returning
     /// transactions. If any search conditions are changed, the query offset
     /// will change and you must restart your search iteration.
     #[serde(skip_serializing_if = "Option::is_none")]
-    #[nullable(option_usize)]
+    #[unchecked(option_usize)]
     pub offset: Option<isize>,
     /// limit is the maximum number of transactions to return in one call. The
     /// implementation may return "= limit transactions.
     #[serde(skip_serializing_if = "Option::is_none")]
-    #[nullable(option_usize)]
+    #[unchecked(option_usize)]
     pub limit: Option<isize>,
     /// The `TransactionIdentifier` uniquely identifies a transaction in a
     /// particular network and block or in the mempool.
     #[serde(skip_serializing_if = "Option::is_none")]
-    #[nullable(retain)]
+    #[unchecked(retain)]
     pub transaction_identifier: Option<TransactionIdentifier>,
     /// The `AccountIdentifier` uniquely identifies an account within a network.
     /// All fields in the `account_identifier` are utilized to determine this
     /// uniqueness (including the `metadata` field, if populated).
     #[serde(skip_serializing_if = "Option::is_none")]
-    #[nullable(retain)]
+    #[unchecked(retain)]
     pub account_identifier: Option<AccountIdentifier>,
     /// `CoinIdentifier` uniquely identifies a [`Coin`].
     #[serde(skip_serializing_if = "Option::is_none")]
-    #[nullable(retain)]
+    #[unchecked(retain)]
     pub coin_identifier: Option<CoinIdentifier>,
     /// `Currency` is composed of a canonical Symbol and Decimals. This Decimals
     /// value is used to convert an [`Amount`].value from atomic units
     /// (Satoshis) to standard units (Bitcoins).
     #[serde(skip_serializing_if = "Option::is_none")]
-    #[nullable(retain)]
-    pub currency: Option<NullableCurrency>,
+    #[unchecked(retain)]
+    pub currency: Option<UncheckedCurrency>,
     /// status is the network-specific operation type.
     #[serde(skip_serializing_if = "Option::is_none")]
-    #[nullable(retain)]
+    #[unchecked(retain)]
     pub status: Option<String>,
     /// type is the network-specific operation type.
     #[serde(rename = "type")]
-    #[nullable(retain)]
+    #[unchecked(retain)]
     pub type_: Option<String>,
     /// address is [`AccountIdentifier`].address. This is used to get all
     /// transactions related to an [`AccountIdentifier`].address, regardless of
     /// [`SubAccountIdentifier`].
     #[serde(skip_serializing_if = "Option::is_none")]
-    #[nullable(retain)]
+    #[unchecked(retain)]
     pub address: Option<String>,
     /// success is a synthetic condition populated by parsing network-specific
     /// operation statuses (using the mapping provided in `/network/options`).
     #[serde(skip_serializing_if = "Option::is_none")]
-    #[nullable(retain)]
+    #[unchecked(retain)]
     pub success: Option<bool>,
 }

--- a/crates/mentat-types/src/requests/search_transactions.rs
+++ b/crates/mentat-types/src/requests/search_transactions.rs
@@ -22,19 +22,19 @@ pub struct NullableSearchTransactionsRequest {
     /// possible a newly synced block will interfere with paginated transaction
     /// queries (as the offset could become invalid with newly added rows).
     #[serde(skip_serializing_if = "Option::is_none")]
-    #[nullable(retain)]
-    pub max_block: Option<i64>,
+    #[nullable(option_usize)]
+    pub max_block: Option<isize>,
     /// offset is the offset into the query result to start returning
     /// transactions. If any search conditions are changed, the query offset
     /// will change and you must restart your search iteration.
     #[serde(skip_serializing_if = "Option::is_none")]
-    #[nullable(retain)]
-    pub offset: Option<i64>,
+    #[nullable(option_usize)]
+    pub offset: Option<isize>,
     /// limit is the maximum number of transactions to return in one call. The
     /// implementation may return "= limit transactions.
     #[serde(skip_serializing_if = "Option::is_none")]
-    #[nullable(retain)]
-    pub limit: Option<i64>,
+    #[nullable(option_usize)]
+    pub limit: Option<isize>,
     /// The `TransactionIdentifier` uniquely identifies a transaction in a
     /// particular network and block or in the mempool.
     #[serde(skip_serializing_if = "Option::is_none")]

--- a/crates/mentat-types/src/responses/account_balance.rs
+++ b/crates/mentat-types/src/responses/account_balance.rs
@@ -13,7 +13,7 @@ pub struct NullableAccountBalanceResponse {
     /// The `block_identifier` uniquely identifies a block in a particular
     /// network.
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub block_identifier: Option<BlockIdentifier>,
+    pub block_identifier: Option<NullableBlockIdentifier>,
     /// A single account may have a balance in multiple currencies.
     #[serde(
         skip_serializing_if = "Vec::is_empty",

--- a/crates/mentat-types/src/responses/account_balance.rs
+++ b/crates/mentat-types/src/responses/account_balance.rs
@@ -7,19 +7,19 @@ use super::*;
 /// (ex: an ERC-20 token balance on a few smart contracts), an account balance
 /// request must be made with each [`AccountIdentifier`]. The coins field was
 /// removed and replaced by by `/account/coins` in v1.4.7.
-#[derive(Clone, Debug, Default, Deserialize, Serialize, Nullable)]
+#[derive(Clone, Debug, Default, Deserialize, Serialize, Unchecked)]
 #[serde(default)]
-pub struct NullableAccountBalanceResponse {
+pub struct UncheckedAccountBalanceResponse {
     /// The `block_identifier` uniquely identifies a block in a particular
     /// network.
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub block_identifier: Option<NullableBlockIdentifier>,
+    pub block_identifier: Option<UncheckedBlockIdentifier>,
     /// A single account may have a balance in multiple currencies.
     #[serde(
         skip_serializing_if = "Vec::is_empty",
         deserialize_with = "null_default"
     )]
-    pub balances: Vec<Option<NullableAmount>>,
+    pub balances: Vec<Option<UncheckedAmount>>,
     /// Account-based blockchains that utilize a nonce or sequence number should
     /// include that number in the metadata. This number could be unique to the
     /// identifier or global across the account address.

--- a/crates/mentat-types/src/responses/account_coins.rs
+++ b/crates/mentat-types/src/responses/account_coins.rs
@@ -6,13 +6,13 @@ use super::*;
 
 /// `AccountCoinsResponse` is returned on the `/account/coins` endpoint and
 /// includes all unspent [`Coin`]s owned by an [`AccountIdentifier`].
-#[derive(Clone, Debug, Default, Deserialize, Serialize, Nullable)]
+#[derive(Clone, Debug, Default, Deserialize, Serialize, Unchecked)]
 #[serde(default)]
-pub struct NullableAccountCoinsResponse {
+pub struct UncheckedAccountCoinsResponse {
     /// The `block_identifier` uniquely identifies a block in a particular
     /// network.
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub block_identifier: Option<NullableBlockIdentifier>,
+    pub block_identifier: Option<UncheckedBlockIdentifier>,
     /// If a blockchain is UTXO-based, all unspent `Coin`s owned by an
     /// `account_identifier` should be returned alongside the balance. It is
     /// highly recommended to populate this field so that users of the Rosetta
@@ -23,7 +23,7 @@ pub struct NullableAccountCoinsResponse {
         skip_serializing_if = "Vec::is_empty",
         deserialize_with = "null_default"
     )]
-    pub coins: Vec<Option<NullableCoin>>,
+    pub coins: Vec<Option<UncheckedCoin>>,
     /// Account-based blockchains that utilize a nonce or sequence number should
     /// include that number in the `metadata`. This number could be unique to
     /// the identifier or global across the account address. Account-based

--- a/crates/mentat-types/src/responses/account_coins.rs
+++ b/crates/mentat-types/src/responses/account_coins.rs
@@ -12,7 +12,7 @@ pub struct NullableAccountCoinsResponse {
     /// The `block_identifier` uniquely identifies a block in a particular
     /// network.
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub block_identifier: Option<BlockIdentifier>,
+    pub block_identifier: Option<NullableBlockIdentifier>,
     /// If a blockchain is UTXO-based, all unspent `Coin`s owned by an
     /// `account_identifier` should be returned alongside the balance. It is
     /// highly recommended to populate this field so that users of the Rosetta

--- a/crates/mentat-types/src/responses/block.rs
+++ b/crates/mentat-types/src/responses/block.rs
@@ -11,9 +11,9 @@ use super::*;
 /// MUST still form a canonical, connected chain of blocks where each block has
 /// a unique index. In other words, the [`PartialBlockIdentifier`] of a block
 /// after an omitted block should reference the last non-omitted block.
-#[derive(Clone, Debug, Default, Deserialize, Serialize, Nullable)]
+#[derive(Clone, Debug, Default, Deserialize, Serialize, Unchecked)]
 #[serde(default)]
-pub struct NullableBlockResponse {
+pub struct UncheckedBlockResponse {
     /// `Block`s contain an array of [`Transaction`]s that occurred at a
     /// particular [`BlockIdentifier`]. A hard requirement for blocks
     /// returned by Rosetta implementations is that they MUST be
@@ -21,8 +21,8 @@ pub struct NullableBlockResponse {
     /// identified by a specific [`BlockIdentifier`], all future calls for
     /// that same [`BlockIdentifier`] must return the same block contents.
     #[serde(skip_serializing_if = "Option::is_none")]
-    #[nullable(retain)]
-    pub block: Option<NullableBlock>,
+    #[unchecked(retain)]
+    pub block: Option<UncheckedBlock>,
     /// Some blockchains may require additional transactions to be fetched that
     /// weren't returned in the block response (ex: block only returns
     /// transaction hashes). For blockchains with a lot of transactions in each

--- a/crates/mentat-types/src/responses/block_transaction.rs
+++ b/crates/mentat-types/src/responses/block_transaction.rs
@@ -4,10 +4,10 @@ use super::*;
 
 /// A [`BlockTransactionResponse`] contains information about a block
 /// transaction.
-#[derive(Clone, Debug, Default, Deserialize, Serialize, Nullable)]
+#[derive(Clone, Debug, Default, Deserialize, Serialize, Unchecked)]
 #[serde(default)]
-pub struct NullableBlockTransactionResponse {
+pub struct UncheckedBlockTransactionResponse {
     /// [`Transaction`]
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub transaction: Option<NullableTransaction>,
+    pub transaction: Option<UncheckedTransaction>,
 }

--- a/crates/mentat-types/src/responses/call.rs
+++ b/crates/mentat-types/src/responses/call.rs
@@ -3,9 +3,9 @@
 use super::*;
 
 /// [`CallResponse`] contains the result of a `/call` invocation.
-#[derive(Clone, Debug, Default, Deserialize, Serialize, Nullable)]
+#[derive(Clone, Debug, Default, Deserialize, Serialize, Unchecked)]
 #[serde(default)]
-pub struct NullableCallResponse {
+pub struct UncheckedCallResponse {
     /// Result contains the result of the `/call` invocation. This result will
     /// not be inspected or interpreted by Rosetta tooling and is left to
     /// the caller to decode.

--- a/crates/mentat-types/src/responses/construction_combine.rs
+++ b/crates/mentat-types/src/responses/construction_combine.rs
@@ -5,9 +5,9 @@ use super::*;
 /// `ConstructionCombineResponse` is returned by `/construction/combine`. The
 /// network payload will be sent directly to the `/construction/submit`
 /// endpoint.
-#[derive(Clone, Debug, Default, Deserialize, Serialize, Nullable)]
+#[derive(Clone, Debug, Default, Deserialize, Serialize, Unchecked)]
 #[serde(default)]
-pub struct NullableConstructionCombineResponse {
+pub struct UncheckedConstructionCombineResponse {
     #[allow(clippy::missing_docs_in_private_items)]
     pub signed_transaction: String,
 }

--- a/crates/mentat-types/src/responses/construction_derive.rs
+++ b/crates/mentat-types/src/responses/construction_derive.rs
@@ -7,23 +7,23 @@ use super::*;
 
 /// [`ConstructionDeriveResponse`] is returned by the `/construction/derive`
 /// endpoint.
-#[derive(Clone, Debug, Default, PartialEq, Eq, Nullable)]
-pub struct NullableConstructionDeriveResponse {
+#[derive(Clone, Debug, Default, PartialEq, Eq, Unchecked)]
+pub struct UncheckedConstructionDeriveResponse {
     /// [DEPRECATED by `account_identifier` in v1.4.4] Address in
     /// network-specific format.
-    #[nullable(retain)]
+    #[unchecked(retain)]
     pub address: Option<String>,
     /// The [`AccountIdentifier`] uniquely identifies an account within a
     /// network. All fields in the `account_identifier` are utilized to
     /// determine this uniqueness (including the metadata field, if
     /// populated).
-    #[nullable(retain)]
+    #[unchecked(retain)]
     pub account_identifier: Option<AccountIdentifier>,
     #[allow(clippy::missing_docs_in_private_items)]
     pub metadata: IndexMap<String, Value>,
 }
 
-impl Serialize for NullableConstructionDeriveResponse {
+impl Serialize for UncheckedConstructionDeriveResponse {
     fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
     where
         S: serde::Serializer,
@@ -58,7 +58,7 @@ pub struct ConstructionDeriveResponsePre {
     pub metadata: IndexMap<String, Value>,
 }
 
-impl<'de> Deserialize<'de> for NullableConstructionDeriveResponse {
+impl<'de> Deserialize<'de> for UncheckedConstructionDeriveResponse {
     fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
     where
         D: serde::Deserializer<'de>,
@@ -74,7 +74,7 @@ impl<'de> Deserialize<'de> for NullableConstructionDeriveResponse {
             })
         };
 
-        Ok(NullableConstructionDeriveResponse {
+        Ok(UncheckedConstructionDeriveResponse {
             address: None,
             account_identifier,
             metadata: pre.metadata,

--- a/crates/mentat-types/src/responses/construction_metadata.rs
+++ b/crates/mentat-types/src/responses/construction_metadata.rs
@@ -11,9 +11,9 @@ use super::*;
 /// transaction with a different account that can pay the suggested fee.
 /// Suggested fee is an array in case fee payment must occur in multiple
 /// currencies.
-#[derive(Clone, Debug, Default, Deserialize, Serialize, Nullable)]
+#[derive(Clone, Debug, Default, Deserialize, Serialize, Unchecked)]
 #[serde(default)]
-pub struct NullableConstructionMetadataResponse {
+pub struct UncheckedConstructionMetadataResponse {
     #[allow(clippy::missing_docs_in_private_items)]
     #[serde(skip_serializing_if = "Option::is_none")]
     pub metadata: Option<IndexMap<String, Value>>,
@@ -22,5 +22,5 @@ pub struct NullableConstructionMetadataResponse {
         skip_serializing_if = "Vec::is_empty",
         deserialize_with = "null_default"
     )]
-    pub suggested_fee: Vec<Option<NullableAmount>>,
+    pub suggested_fee: Vec<Option<UncheckedAmount>>,
 }

--- a/crates/mentat-types/src/responses/construction_parse.rs
+++ b/crates/mentat-types/src/responses/construction_parse.rs
@@ -8,10 +8,10 @@ use super::*;
 /// [`ConstructionParseResponse`] contains an array of operations that occur in
 /// a transaction blob. This should match the array of operations provided to
 /// `/construction/preprocess` and `/construction/payloads`.
-#[derive(Clone, Debug, Default, PartialEq, Eq, Nullable)]
-pub struct NullableConstructionParseResponse {
+#[derive(Clone, Debug, Default, PartialEq, Eq, Unchecked)]
+pub struct UncheckedConstructionParseResponse {
     #[allow(clippy::missing_docs_in_private_items)]
-    pub operations: Vec<Option<NullableOperation>>,
+    pub operations: Vec<Option<UncheckedOperation>>,
     /// [DEPRECATED by `account_identifier_signers` in v1.4.4] All signers
     /// (addresses) of a particular transaction. If the transaction is unsigned,
     /// it should be empty.
@@ -22,7 +22,7 @@ pub struct NullableConstructionParseResponse {
     pub metadata: IndexMap<String, Value>,
 }
 
-impl Serialize for NullableConstructionParseResponse {
+impl Serialize for UncheckedConstructionParseResponse {
     fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
     where
         S: serde::Serializer,
@@ -61,7 +61,7 @@ pub struct ConstructionParseResponsePre {
         skip_serializing_if = "Vec::is_empty",
         deserialize_with = "null_default"
     )]
-    pub operations: Vec<Option<NullableOperation>>,
+    pub operations: Vec<Option<UncheckedOperation>>,
     #[serde(
         skip_serializing_if = "Vec::is_empty",
         deserialize_with = "null_default"
@@ -76,7 +76,7 @@ pub struct ConstructionParseResponsePre {
     pub metadata: IndexMap<String, Value>,
 }
 
-impl<'de> Deserialize<'de> for NullableConstructionParseResponse {
+impl<'de> Deserialize<'de> for UncheckedConstructionParseResponse {
     fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
     where
         D: serde::Deserializer<'de>,
@@ -98,7 +98,7 @@ impl<'de> Deserialize<'de> for NullableConstructionParseResponse {
                 pre.account_identifier_signers
             };
 
-        Ok(NullableConstructionParseResponse {
+        Ok(UncheckedConstructionParseResponse {
             operations: pre.operations,
             signers: Vec::new(),
             account_identifier_signers,

--- a/crates/mentat-types/src/responses/construction_payloads.rs
+++ b/crates/mentat-types/src/responses/construction_payloads.rs
@@ -6,9 +6,9 @@ use super::*;
 /// It contains an unsigned transaction blob (that is usually needed to
 /// construct the a network transaction from a collection of signatures) and an
 /// array of payloads that must be signed by the caller.
-#[derive(Clone, Debug, Default, Deserialize, Serialize, Nullable)]
+#[derive(Clone, Debug, Default, Deserialize, Serialize, Unchecked)]
 #[serde(default)]
-pub struct NullableConstructionPayloadsResponse {
+pub struct UncheckedConstructionPayloadsResponse {
     #[allow(clippy::missing_docs_in_private_items)]
     pub unsigned_transaction: String,
     #[allow(clippy::missing_docs_in_private_items)]
@@ -16,5 +16,5 @@ pub struct NullableConstructionPayloadsResponse {
         skip_serializing_if = "Vec::is_empty",
         deserialize_with = "null_default"
     )]
-    pub payloads: Vec<Option<NullableSigningPayload>>,
+    pub payloads: Vec<Option<UncheckedSigningPayload>>,
 }

--- a/crates/mentat-types/src/responses/construction_preprocess.rs
+++ b/crates/mentat-types/src/responses/construction_preprocess.rs
@@ -12,9 +12,9 @@ use super::*;
 /// `required_public_keys` with the [`AccountIdentifier`]s associated with the
 /// desired [`PublicKey`]s. If it is not necessary to retrieve any
 /// [`PublicKey`]s for construction, `required_public_keys` should be omitted.
-#[derive(Clone, Debug, Default, Deserialize, Serialize, Nullable)]
+#[derive(Clone, Debug, Default, Deserialize, Serialize, Unchecked)]
 #[serde(default)]
-pub struct NullableConstructionPreprocessResponse {
+pub struct UncheckedConstructionPreprocessResponse {
     /// The options that will be sent directly to `/construction/metadata` by
     /// the caller.
     #[serde(skip_serializing_if = "IndexMap::is_empty")]

--- a/crates/mentat-types/src/responses/event_blocks.rs
+++ b/crates/mentat-types/src/responses/event_blocks.rs
@@ -8,7 +8,8 @@ use super::*;
 #[serde(default)]
 pub struct NullableEventsBlocksResponse {
     /// `max_sequence` is the maximum available sequence number to fetch.
-    pub max_sequence: i64,
+    #[nullable(usize)]
+    pub max_sequence: isize,
     /// events is an array of [`BlockEvent`]s indicating the order to add and
     /// remove blocks to maintain a canonical view of blockchain state.
     /// Lightweight clients can use this event stream to update state

--- a/crates/mentat-types/src/responses/event_blocks.rs
+++ b/crates/mentat-types/src/responses/event_blocks.rs
@@ -4,11 +4,11 @@ use super::*;
 
 /// `EventsBlocksResponse` contains an ordered collection of [`BlockEvent`]s and
 /// the max retrievable sequence.
-#[derive(Clone, Debug, Default, Deserialize, Serialize, Nullable)]
+#[derive(Clone, Debug, Default, Deserialize, Serialize, Unchecked)]
 #[serde(default)]
-pub struct NullableEventsBlocksResponse {
+pub struct UncheckedEventsBlocksResponse {
     /// `max_sequence` is the maximum available sequence number to fetch.
-    #[nullable(usize)]
+    #[unchecked(usize)]
     pub max_sequence: isize,
     /// events is an array of [`BlockEvent`]s indicating the order to add and
     /// remove blocks to maintain a canonical view of blockchain state.
@@ -18,5 +18,5 @@ pub struct NullableEventsBlocksResponse {
         skip_serializing_if = "Vec::is_empty",
         deserialize_with = "null_default"
     )]
-    pub events: Vec<Option<NullableBlockEvent>>,
+    pub events: Vec<Option<UncheckedBlockEvent>>,
 }

--- a/crates/mentat-types/src/responses/mempool.rs
+++ b/crates/mentat-types/src/responses/mempool.rs
@@ -4,9 +4,9 @@ use super::*;
 
 /// A [`MempoolResponse`] contains all transaction identifiers in the mempool
 /// for a particular `network_identifier`.
-#[derive(Clone, Debug, Default, Deserialize, Serialize, Nullable)]
+#[derive(Clone, Debug, Default, Deserialize, Serialize, Unchecked)]
 #[serde(default)]
-pub struct NullableMempoolResponse {
+pub struct UncheckedMempoolResponse {
     #[allow(clippy::missing_docs_in_private_items)]
     #[serde(
         skip_serializing_if = "Vec::is_empty",

--- a/crates/mentat-types/src/responses/mempool_transaction.rs
+++ b/crates/mentat-types/src/responses/mempool_transaction.rs
@@ -7,13 +7,13 @@ use super::*;
 /// A [`MempoolTransactionResponse`] contains an estimate of a mempool
 /// transaction. It may not be possible to know the full impact of a transaction
 /// in the mempool (ex: fee paid).
-#[derive(Clone, Debug, Default, Deserialize, Serialize, Nullable)]
+#[derive(Clone, Debug, Default, Deserialize, Serialize, Unchecked)]
 #[serde(default)]
-pub struct NullableMempoolTransactionResponse {
+pub struct UncheckedMempoolTransactionResponse {
     /// [`Transaction`]s contain an array of [`Operation`]s that are
     /// attributable to the same [`TransactionIdentifier`].
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub transaction: Option<NullableTransaction>,
+    pub transaction: Option<UncheckedTransaction>,
     #[allow(clippy::missing_docs_in_private_items)]
     #[serde(skip_serializing_if = "IndexMap::is_empty")]
     pub metadata: IndexMap<String, Value>,

--- a/crates/mentat-types/src/responses/network_list.rs
+++ b/crates/mentat-types/src/responses/network_list.rs
@@ -4,9 +4,9 @@ use super::*;
 
 /// A [`NetworkListResponse`] contains all [`NetworkIdentifier`]s that the node
 /// can serve information for.
-#[derive(Clone, Debug, Default, Deserialize, Serialize, Nullable)]
+#[derive(Clone, Debug, Default, Deserialize, Serialize, Unchecked)]
 #[serde(default)]
-pub struct NullableNetworkListResponse {
+pub struct UncheckedNetworkListResponse {
     #[allow(clippy::missing_docs_in_private_items)]
     #[serde(
         skip_serializing_if = "Vec::is_empty",

--- a/crates/mentat-types/src/responses/network_options.rs
+++ b/crates/mentat-types/src/responses/network_options.rs
@@ -4,9 +4,9 @@ use super::*;
 
 /// [`NetworkOptionsResponse`] contains information about the versioning of the
 /// node and the allowed operation statuses, operation types, and errors.
-#[derive(Clone, Debug, Default, Deserialize, Serialize, Nullable)]
+#[derive(Clone, Debug, Default, Deserialize, Serialize, Unchecked)]
 #[serde(default)]
-pub struct NullableNetworkOptionsResponse {
+pub struct UncheckedNetworkOptionsResponse {
     /// The [`Version`] object is utilized to inform the client of the versions
     /// of different components of the Rosetta implementation.
     #[serde(skip_serializing_if = "Option::is_none")]
@@ -18,5 +18,5 @@ pub struct NullableNetworkOptionsResponse {
     /// receive some response that contains any of the above information
     /// that is not specified here.
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub allow: Option<NullableAllow>,
+    pub allow: Option<UncheckedAllow>,
 }

--- a/crates/mentat-types/src/responses/network_status.rs
+++ b/crates/mentat-types/src/responses/network_status.rs
@@ -19,20 +19,21 @@ pub struct NullableNetworkStatusResponse {
     /// The [`BlockIdentifier`] uniquely identifies a block in a particular
     /// network.
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub current_block_identifier: Option<BlockIdentifier>,
+    pub current_block_identifier: Option<NullableBlockIdentifier>,
     /// The timestamp of the block in milliseconds since the Unix Epoch. The
     /// timestamp is stored in milliseconds because some blockchains produce
     /// blocks more often than once a second.
-    pub current_block_timestamp: i64,
+    #[nullable(usize)]
+    pub current_block_timestamp: isize,
     /// The [`BlockIdentifier`] uniquely identifies a block in a particular
     /// network.
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub genesis_block_identifier: Option<BlockIdentifier>,
+    pub genesis_block_identifier: Option<NullableBlockIdentifier>,
     /// The [`BlockIdentifier`] uniquely identifies a block in a particular
     /// network.
     #[serde(skip_serializing_if = "Option::is_none")]
     #[nullable(retain)]
-    pub oldest_block_identifier: Option<BlockIdentifier>,
+    pub oldest_block_identifier: Option<NullableBlockIdentifier>,
     /// `SyncStatus` is used to provide additional context about an
     /// implementation's sync status. This object is often used by
     /// implementations to indicate healthiness when block data cannot be
@@ -40,7 +41,7 @@ pub struct NullableNetworkStatusResponse {
     /// comparing the timestamp of the most recent block with the current time.
     #[serde(skip_serializing_if = "Option::is_none")]
     #[nullable(retain)]
-    pub sync_status: Option<SyncStatus>,
+    pub sync_status: Option<NullableSyncStatus>,
     #[allow(clippy::missing_docs_in_private_items)]
     #[serde(
         skip_serializing_if = "Vec::is_empty",

--- a/crates/mentat-types/src/responses/network_status.rs
+++ b/crates/mentat-types/src/responses/network_status.rs
@@ -13,35 +13,35 @@ use super::*;
 /// `sync_status` should be populated so that clients can still monitor
 /// healthiness. Without this field, it may appear that the implementation is
 /// stuck syncing and needs to be terminated.
-#[derive(Clone, Debug, Default, Deserialize, Serialize, Nullable, PartialEq, Eq)]
+#[derive(Clone, Debug, Default, Deserialize, Serialize, Unchecked, PartialEq, Eq)]
 #[serde(default)]
-pub struct NullableNetworkStatusResponse {
+pub struct UncheckedNetworkStatusResponse {
     /// The [`BlockIdentifier`] uniquely identifies a block in a particular
     /// network.
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub current_block_identifier: Option<NullableBlockIdentifier>,
+    pub current_block_identifier: Option<UncheckedBlockIdentifier>,
     /// The timestamp of the block in milliseconds since the Unix Epoch. The
     /// timestamp is stored in milliseconds because some blockchains produce
     /// blocks more often than once a second.
-    #[nullable(usize)]
+    #[unchecked(usize)]
     pub current_block_timestamp: isize,
     /// The [`BlockIdentifier`] uniquely identifies a block in a particular
     /// network.
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub genesis_block_identifier: Option<NullableBlockIdentifier>,
+    pub genesis_block_identifier: Option<UncheckedBlockIdentifier>,
     /// The [`BlockIdentifier`] uniquely identifies a block in a particular
     /// network.
     #[serde(skip_serializing_if = "Option::is_none")]
-    #[nullable(retain)]
-    pub oldest_block_identifier: Option<NullableBlockIdentifier>,
+    #[unchecked(retain)]
+    pub oldest_block_identifier: Option<UncheckedBlockIdentifier>,
     /// `SyncStatus` is used to provide additional context about an
     /// implementation's sync status. This object is often used by
     /// implementations to indicate healthiness when block data cannot be
     /// queried until some sync phase completes or cannot be determined by
     /// comparing the timestamp of the most recent block with the current time.
     #[serde(skip_serializing_if = "Option::is_none")]
-    #[nullable(retain)]
-    pub sync_status: Option<NullableSyncStatus>,
+    #[unchecked(retain)]
+    pub sync_status: Option<UncheckedSyncStatus>,
     #[allow(clippy::missing_docs_in_private_items)]
     #[serde(
         skip_serializing_if = "Vec::is_empty",

--- a/crates/mentat-types/src/responses/search_transactions.rs
+++ b/crates/mentat-types/src/responses/search_transactions.rs
@@ -22,11 +22,12 @@ pub struct NullableSearchTransactionsResponse {
     /// `total_count` is the number of results for a given search. Callers
     /// typically use this value to concurrently fetch results by offset or to
     /// display a virtual page number associated with results.
-    pub total_count: i64,
+    #[nullable(usize)]
+    pub total_count: isize,
     /// `next_offset` is the next offset to use when paginating through
     /// transaction results. If this field is not populated, there are no more
     /// transactions to query.
     #[serde(skip_serializing_if = "Option::is_none")]
-    #[nullable(retain)]
-    pub next_offset: Option<i64>,
+    #[nullable(option_usize)]
+    pub next_offset: Option<isize>,
 }

--- a/crates/mentat-types/src/responses/search_transactions.rs
+++ b/crates/mentat-types/src/responses/search_transactions.rs
@@ -6,9 +6,9 @@ use super::*;
 /// [`BlockTransaction`]s that match the query in
 /// [`crate::requests::SearchTransactionsRequest`]. These [`BlockTransaction`]s
 /// are sorted from most recent block to oldest block.
-#[derive(Clone, Debug, Default, Deserialize, Serialize, Nullable)]
+#[derive(Clone, Debug, Default, Deserialize, Serialize, Unchecked)]
 #[serde(default)]
-pub struct NullableSearchTransactionsResponse {
+pub struct UncheckedSearchTransactionsResponse {
     /// transactions is an array of [`BlockTransaction`]s sorted by most recent
     /// [`BlockIdentifier`] (meaning that transactions in recent blocks appear
     /// first). If there are many transactions for a particular search,
@@ -18,16 +18,16 @@ pub struct NullableSearchTransactionsResponse {
         skip_serializing_if = "Vec::is_empty",
         deserialize_with = "null_default"
     )]
-    pub transactions: Vec<Option<NullableBlockTransaction>>,
+    pub transactions: Vec<Option<UncheckedBlockTransaction>>,
     /// `total_count` is the number of results for a given search. Callers
     /// typically use this value to concurrently fetch results by offset or to
     /// display a virtual page number associated with results.
-    #[nullable(usize)]
+    #[unchecked(usize)]
     pub total_count: isize,
     /// `next_offset` is the next offset to use when paginating through
     /// transaction results. If this field is not populated, there are no more
     /// transactions to query.
     #[serde(skip_serializing_if = "Option::is_none")]
-    #[nullable(option_usize)]
+    #[unchecked(option_usize)]
     pub next_offset: Option<isize>,
 }

--- a/crates/mentat-types/src/responses/transaction_identifier.rs
+++ b/crates/mentat-types/src/responses/transaction_identifier.rs
@@ -7,9 +7,9 @@ use super::*;
 /// [`TransactionIdentifierResponse`] contains the `transaction_identifier` of a
 /// transaction that was submitted to either `/construction/hash` or
 /// `/construction/submit`.
-#[derive(Clone, Debug, Default, Deserialize, Serialize, Nullable)]
+#[derive(Clone, Debug, Default, Deserialize, Serialize, Unchecked)]
 #[serde(default)]
-pub struct NullableTransactionIdentifierResponse {
+pub struct UncheckedTransactionIdentifierResponse {
     /// The [`TransactionIdentifier`] uniquely identifies a transaction in a
     /// particular network and block or in the mempool.
     #[serde(skip_serializing_if = "Option::is_none")]

--- a/crates/mentat-types/src/serialize_test.rs
+++ b/crates/mentat-types/src/serialize_test.rs
@@ -9,11 +9,11 @@ struct HexBytesTester {
 
 #[test]
 fn test_custom_marshal_public_key() {
-    let s = NullablePublicKey {
+    let s = UncheckedPublicKey {
         bytes: "hsdjkfhkasjfhkjasdhfkjasdnfkjabsdfkjhakjsfdhjksadhfjk23478923645yhsdfn"
             .as_bytes()
             .to_vec(),
-        curve_type: NullableCurveType::SECP256K1.into(),
+        curve_type: UncheckedCurveType::SECP256K1.into(),
     };
     let json = serde_json::to_string(&s).unwrap();
 
@@ -23,21 +23,21 @@ fn test_custom_marshal_public_key() {
     assert_eq!(b, s.bytes);
 
     // Full Check
-    let s2: NullablePublicKey = serde_json::from_str(&json).unwrap();
+    let s2: UncheckedPublicKey = serde_json::from_str(&json).unwrap();
     assert_eq!(s.bytes, s2.bytes);
 
     // Invalid Hex Check
-    let s3: Result<NullablePublicKey, _> = serde_json::from_str("{ \"hex_bytes\": \"hello\" }");
+    let s3: Result<UncheckedPublicKey, _> = serde_json::from_str("{ \"hex_bytes\": \"hello\" }");
     assert!(s3.is_err());
 }
 
 #[test]
 fn test_custom_marshal_signature() {
-    let s = NullableSignature {
+    let s = UncheckedSignature {
         bytes: "hsdjkfhkasjfhkjasdhfkjasdnfkjabsdfkjhakjsfdhjksadhfjk23478923645yhsdfn"
             .as_bytes()
             .to_vec(),
-        signature_type: NullableSignatureType::ECDSA.into(),
+        signature_type: UncheckedSignatureType::ECDSA.into(),
         ..Default::default()
     };
     let json = serde_json::to_string(&s).unwrap();
@@ -48,17 +48,17 @@ fn test_custom_marshal_signature() {
     assert_eq!(b, s.bytes);
 
     // Full Check
-    let s2: NullableSignature = serde_json::from_str(&json).unwrap();
+    let s2: UncheckedSignature = serde_json::from_str(&json).unwrap();
     assert_eq!(s.bytes, s2.bytes);
 
     // Invalid Hex Check
-    let s3: Result<NullableSignature, _> = serde_json::from_str("{ \"hex_bytes\": \"hello\" }");
+    let s3: Result<UncheckedSignature, _> = serde_json::from_str("{ \"hex_bytes\": \"hello\" }");
     assert!(s3.is_err());
 }
 
 #[test]
 fn test_custom_marshal_signing_payload() {
-    let s = NullableSigningPayload {
+    let s = UncheckedSigningPayload {
         account_identifier: Some(AccountIdentifier {
             address: "addr1".into(),
             sub_account: Some(SubAccountIdentifier {
@@ -80,16 +80,16 @@ fn test_custom_marshal_signing_payload() {
     assert_eq!(b, s.bytes);
 
     // Full Check
-    let s2: NullableSigningPayload = serde_json::from_str(&json).unwrap();
+    let s2: UncheckedSigningPayload = serde_json::from_str(&json).unwrap();
     assert_eq!(s, s2);
 
     // Invalid Hex Check
-    let s3: Result<NullableSigningPayload, _> =
+    let s3: Result<UncheckedSigningPayload, _> =
         serde_json::from_str("{ \"hex_bytes\": \"hello\" }");
     assert!(s3.is_err());
 
     // Deserialize Fields
-    let s4: NullableSigningPayload =
+    let s4: UncheckedSigningPayload =
         serde_json::from_str("{ \"address\": \"hello\", \"hex_bytes\": \"74657374\" }").unwrap();
     assert_eq!(
         Some(AccountIdentifier {
@@ -101,7 +101,7 @@ fn test_custom_marshal_signing_payload() {
     assert_eq!("test".as_bytes(), &s4.bytes);
 
     // Deserialize Fields (empty address)
-    let s5: NullableSigningPayload =
+    let s5: UncheckedSigningPayload =
         serde_json::from_str("{ \"hex_bytes\": \"74657374\" }").unwrap();
     assert!(s5.account_identifier.is_none());
     assert_eq!("test".as_bytes(), &s5.bytes);
@@ -109,7 +109,7 @@ fn test_custom_marshal_signing_payload() {
 
 #[test]
 fn test_custom_construction_derive_response() {
-    let s = NullableConstructionDeriveResponse {
+    let s = UncheckedConstructionDeriveResponse {
         account_identifier: Some(AccountIdentifier {
             address: "addr1".into(),
             ..Default::default()
@@ -121,11 +121,11 @@ fn test_custom_construction_derive_response() {
     // TODO Simple check
 
     // Full Check
-    let s2: NullableConstructionDeriveResponse = serde_json::from_str(&json).unwrap();
+    let s2: UncheckedConstructionDeriveResponse = serde_json::from_str(&json).unwrap();
     assert_eq!(s, s2);
 
     // Deserialize Fields
-    let s3: NullableConstructionDeriveResponse =
+    let s3: UncheckedConstructionDeriveResponse =
         serde_json::from_str("{ \"address\": \"hello\", \"hex_bytes\": \"74657374\" }").unwrap();
     assert_eq!(
         Some(AccountIdentifier {
@@ -136,12 +136,12 @@ fn test_custom_construction_derive_response() {
     );
 
     // Deserialize Fields (empty address)
-    let s4: NullableConstructionDeriveResponse =
+    let s4: UncheckedConstructionDeriveResponse =
         serde_json::from_str("{ \"hex_bytes\": \"74657374\" }").unwrap();
     assert!(s4.account_identifier.is_none());
 
     // Deserialize Fields (override)
-    let s5: NullableConstructionDeriveResponse =
+    let s5: UncheckedConstructionDeriveResponse =
         serde_json::from_str("{ \"address\": \"hello\", \"account_identifier\": { \"address\": \"hello2\" }, \"hex_bytes\": \"74657374\" }").unwrap();
     assert_eq!(
         Some(AccountIdentifier {
@@ -154,7 +154,7 @@ fn test_custom_construction_derive_response() {
 
 #[test]
 fn test_custom_construction_parse_response() {
-    let s = NullableConstructionParseResponse {
+    let s = UncheckedConstructionParseResponse {
         account_identifier_signers: vec![
             Some(AccountIdentifier {
                 address: "addr1".into(),
@@ -177,11 +177,11 @@ fn test_custom_construction_parse_response() {
     // TODO Simple check
 
     // Full Check
-    let s2: NullableConstructionParseResponse = serde_json::from_str(&json).unwrap();
+    let s2: UncheckedConstructionParseResponse = serde_json::from_str(&json).unwrap();
     assert_eq!(s, s2);
 
     // Deserialize Fields
-    let s3: NullableConstructionParseResponse =
+    let s3: UncheckedConstructionParseResponse =
         serde_json::from_str("{ \"signers\": [\"hello\"], \"hex_bytes\": \"74657374\" }").unwrap();
     assert_eq!(
         vec![Some(AccountIdentifier {
@@ -192,12 +192,12 @@ fn test_custom_construction_parse_response() {
     );
 
     // Deserialize Fields (empty address)
-    let s4: NullableConstructionParseResponse =
+    let s4: UncheckedConstructionParseResponse =
         serde_json::from_str("{ \"hex_bytes\": \"74657374\" }").unwrap();
     assert!(s4.signers.is_empty());
 
     // Deserialize Fields (override)
-    let s5: NullableConstructionParseResponse =
+    let s5: UncheckedConstructionParseResponse =
         serde_json::from_str("{ \"signers\": [\"hello\"], \"account_identifier_signers\": [{ \"address\": \"hello2\" }], \"hex_bytes\": \"74657374\" }").unwrap();
     assert_eq!(
         vec![Some(AccountIdentifier {

--- a/crates/mentat-types/src/utils.rs
+++ b/crates/mentat-types/src/utils.rs
@@ -10,10 +10,10 @@ use super::{
     AccountIdentifier,
     Amount,
     BlockIdentifier,
-    NullableAmount,
-    NullableCurrency,
     PartialBlockIdentifier,
     Sortable,
+    UncheckedAmount,
+    UncheckedCurrency,
 };
 
 /// `hash_bytes` returns a hex-encoded sha256 hash of the provided
@@ -94,7 +94,7 @@ pub(crate) fn account_string(account: &AccountIdentifier) -> String {
 
 /// `currency_string` returns a human-readable representation
 /// of a *Currency.
-pub(crate) fn currency_string(currency: &NullableCurrency) -> String {
+pub(crate) fn currency_string(currency: &UncheckedCurrency) -> String {
     if currency.metadata.is_empty() {
         format!("{}:{}", currency.symbol, currency.decimals)
     } else {
@@ -156,9 +156,9 @@ pub fn negate_value(val: &str) -> Result<String, String> {
 /// `extract_amount` returns the Amount from a slice of Balance
 /// pertaining to an AccountAndCurrency.
 pub(crate) fn extract_amount(
-    balances: &[Option<NullableAmount>],
-    currency: Option<&NullableCurrency>,
-) -> NullableAmount {
+    balances: &[Option<UncheckedAmount>],
+    currency: Option<&UncheckedCurrency>,
+) -> UncheckedAmount {
     balances
         .iter()
         .find(|amt| {
@@ -170,7 +170,7 @@ pub(crate) fn extract_amount(
         })
         .cloned()
         .flatten()
-        .unwrap_or(NullableAmount {
+        .unwrap_or(UncheckedAmount {
             value: "0".to_string(),
             currency: currency.cloned(),
             ..Default::default()

--- a/crates/mentat-types/src/utils.rs
+++ b/crates/mentat-types/src/utils.rs
@@ -83,25 +83,26 @@ pub(crate) fn account_string(account: &AccountIdentifier) -> String {
     };
 
     if sub_account.metadata.is_empty() {
-        return format!("{}:{}", account.address, sub_account.address);
+        format!("{}:{}", account.address, sub_account.address)
+    } else {
+        format!(
+            "{}:{}:{:?}",
+            account.address, sub_account.address, sub_account.metadata
+        )
     }
-
-    format!(
-        "{}:{}:{:?}",
-        account.address, sub_account.address, sub_account.metadata
-    )
 }
 
 /// `currency_string` returns a human-readable representation
 /// of a *Currency.
 pub(crate) fn currency_string(currency: &NullableCurrency) -> String {
     if currency.metadata.is_empty() {
-        return format!("{}:{}", currency.symbol, currency.decimals);
+        format!("{}:{}", currency.symbol, currency.decimals)
+    } else {
+        format!(
+            "{}:{}:{:?}",
+            currency.symbol, currency.decimals, currency.metadata
+        )
     }
-    return format!(
-        "{}:{}:{:?}",
-        currency.symbol, currency.decimals, currency.metadata
-    );
 }
 
 /// `big_int` returns a *big.Int representation of a value.

--- a/crates/mentat-types/src/utils_test.rs
+++ b/crates/mentat-types/src/utils_test.rs
@@ -235,7 +235,7 @@ fn test_currency_string() {
     let tests = vec![
         TestCase {
             name: "simple currency",
-            payload: NullableCurrency {
+            payload: UncheckedCurrency {
                 symbol: "BTC".into(),
                 decimals: 8,
                 ..Default::default()
@@ -244,7 +244,7 @@ fn test_currency_string() {
         },
         TestCase {
             name: "currency with string metadata",
-            payload: NullableCurrency {
+            payload: UncheckedCurrency {
                 symbol: "BTC".into(),
                 decimals: 8,
                 metadata: [("issuer".into(), "satoshi".into())].into(),
@@ -253,7 +253,7 @@ fn test_currency_string() {
         },
         TestCase {
             name: "currency with number metadata",
-            payload: NullableCurrency {
+            payload: UncheckedCurrency {
                 symbol: "BTC".into(),
                 decimals: 8,
                 metadata: [("issuer".into(), 1.into())].into(),
@@ -262,7 +262,7 @@ fn test_currency_string() {
         },
         TestCase {
             name: "currency with complex metadata",
-            payload: NullableCurrency {
+            payload: UncheckedCurrency {
                 symbol: "BTC".into(),
                 decimals: 8,
                 metadata: [
@@ -325,25 +325,25 @@ fn test_amount_value() {
 
 #[test]
 fn test_extract_amount() {
-    let currency_1 = Some(NullableCurrency {
+    let currency_1 = Some(UncheckedCurrency {
         symbol: "curr1".into(),
         decimals: 4,
         ..Default::default()
     });
 
-    let currency_2 = Some(NullableCurrency {
+    let currency_2 = Some(UncheckedCurrency {
         symbol: "curr2".into(),
         decimals: 7,
         ..Default::default()
     });
 
-    let amount1 = NullableAmount {
+    let amount1 = UncheckedAmount {
         value: "100".into(),
         currency: currency_1.clone(),
         ..Default::default()
     };
 
-    let amount2 = NullableAmount {
+    let amount2 = UncheckedAmount {
         value: "200".into(),
         currency: currency_2.clone(),
         ..Default::default()
@@ -351,7 +351,7 @@ fn test_extract_amount() {
 
     let balances = &[Some(amount1.clone()), Some(amount2.clone())];
 
-    let bad_cur = Some(NullableCurrency {
+    let bad_cur = Some(UncheckedCurrency {
         symbol: "no cur".into(),
         decimals: 100,
         ..Default::default()

--- a/examples/mentat-cli/src/main.rs
+++ b/examples/mentat-cli/src/main.rs
@@ -5,12 +5,8 @@ use mentat::{
     serde_json::json,
     tokio,
     types::{
-        BlockIdentifier,
-        NetworkIdentifier,
-        NullableAccountBalanceRequest,
-        NullableAccountCoinsRequest,
-        NullableMetadataRequest,
-        PartialBlockIdentifier,
+        BlockIdentifier, NetworkIdentifier, NullableAccountBalanceRequest,
+        NullableAccountCoinsRequest, NullableMetadataRequest, PartialBlockIdentifier,
     },
 };
 
@@ -39,7 +35,7 @@ struct Opts {
     pub(crate) subnetwork: String,
 
     #[clap(long)]
-    pub(crate) index: Option<i64>,
+    pub(crate) index: Option<isize>,
     #[clap(long)]
     pub(crate) hash: Option<String>,
 }

--- a/mentat-macros/src/lib.rs
+++ b/mentat-macros/src/lib.rs
@@ -5,10 +5,9 @@
 
 extern crate proc_macro;
 
-mod nullable;
 mod route_builder;
+mod unchecked;
 
-use nullable::StructBuilder;
 use proc_macro::TokenStream;
 use proc_macro2::{Span, TokenStream as TokenStream2};
 use quote::quote;
@@ -27,6 +26,7 @@ use syn::{
     ReturnType,
     Type,
 };
+use unchecked::StructBuilder;
 
 /// Matches the provided macro argument for the optional `CacheInner` type.
 fn get_cache_inner_type(arg: &NestedMeta) -> Result<&Ident, TokenStream> {
@@ -162,15 +162,15 @@ pub fn main(attr: TokenStream, item: TokenStream) -> TokenStream {
     out.into()
 }
 
-/// creates a non-nullable struct from a nullable struct and implements `From`
+/// creates a non-unchecked struct from a unchecked struct and implements `From`
 /// both ways
-#[proc_macro_derive(Nullable, attributes(nullable))]
-pub fn nullable(item: TokenStream) -> TokenStream {
+#[proc_macro_derive(Unchecked, attributes(unchecked))]
+pub fn unchecked(item: TokenStream) -> TokenStream {
     let item = parse_macro_input!(item as ItemStruct);
     let builder: StructBuilder = StructBuilder::new(&item);
     let new_struct = builder.gen_struct(&item);
-    let from_null = builder.gen_from_nullable_impl(&item);
-    let to_null = builder.gen_to_nullable_impl(&item);
+    let from_null = builder.gen_from_unchecked_impl(&item);
+    let to_null = builder.gen_to_unchecked_impl(&item);
 
     quote!(
         #new_struct

--- a/mentat-macros/src/nullable.rs
+++ b/mentat-macros/src/nullable.rs
@@ -5,8 +5,20 @@ use std::fmt::Debug;
 use proc_macro2::{Punct, Spacing, Span, TokenStream as TokenStream2, TokenTree};
 use quote::ToTokens;
 use syn::{
-    parse_quote, punctuated::Punctuated, token::Brace, Field, FieldValue, Fields, FieldsNamed,
-    Ident, ItemImpl, ItemStruct, Meta, MetaList, NestedMeta, Type,
+    parse_quote,
+    punctuated::Punctuated,
+    token::Brace,
+    Field,
+    FieldValue,
+    Fields,
+    FieldsNamed,
+    Ident,
+    ItemImpl,
+    ItemStruct,
+    Meta,
+    MetaList,
+    NestedMeta,
+    Type,
 };
 
 /// the nullable argument over a struct field


### PR DESCRIPTION
we had i64's in a lot of places where usize's were specified. this was originally done to obey asserter errors, but now that we have separate structs for pre and post assertion i was able to change the related fields to usize.

adds `usize` and `option_usize` tags to the `nullable` macro, changes related i64 fields to usize, added nullable versions of effected structs, and changes code that relied on i64's to rely on usize's instead

effected models:
https://www.rosetta-api.org/docs/models/Allow.html
https://www.rosetta-api.org/docs/models/Block.html
https://www.rosetta-api.org/docs/models/BlockEvent.html
https://www.rosetta-api.org/docs/models/Currency.html
https://www.rosetta-api.org/docs/models/BlockIdentifier.html
https://www.rosetta-api.org/docs/models/OperationIdentifier.html
https://www.rosetta-api.org/docs/models/PartialBlockIdentifier.html
https://www.rosetta-api.org/docs/models/EventsBlocksRequest.html
https://www.rosetta-api.org/docs/models/EventsBlocksResponse.html
https://www.rosetta-api.org/docs/models/NetworkStatusResponse.html
https://www.rosetta-api.org/docs/models/SearchTransactionsRequest.html
https://www.rosetta-api.org/docs/models/SearchTransactionsResponse.html
https://www.rosetta-api.org/docs/models/Error.html
https://www.rosetta-api.org/docs/models/SyncStatus.html